### PR TITLE
Improve Proto Documentation Build and HTML Comment Rendering

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -3116,7 +3116,7 @@ It is in the range [0.0, 1.0]. </p></td>
         </table>
       
         <h3 id="ondewo.t2s.UpdateCustomPhonemizerRequest.UpdateMethod" class="title-badge enum">UpdateCustomPhonemizerRequest.UpdateMethod</h3>
-        <p>The update method to be used.</p>
+        <p>The update method to be used.</p><p>UpdateMethod enum defines the method for updating custom phonemizers.</p>
         <table class="enum-table">
           <thead>
             <tr><td>Name</td><td>Number</td><td>Description</td></tr>

--- a/docs/index.html
+++ b/docs/index.html
@@ -360,7 +360,7 @@
       
         
         <h3 id="ondewo.t2s.Text2Speech" class="title-badge service">Text2Speech</h3>
-        <p>Text2Speech service provides endpoints for text-to-speech generation.</p>
+        <p><p>Text2Speech service provides endpoints for text-to-speech generation.</p></p>
 
         
         <div id="ondewo.t2s.Text2Speech-methods" class="service-methods">Service Methods</div>
@@ -369,147 +369,113 @@
 
           <pre>rpc Synthesize (<a href="#ondewo.t2s.SynthesizeRequest">SynthesizeRequest</a>) returns (<a href="#ondewo.t2s.SynthesizeResponse">SynthesizeResponse)</a></pre>
 
-          Synthesize RPC
-
-Synthesizes a specific text sent in the request with the provided configuration requirements
-and retrieves a response that includes the synthesized text as audio and the requested configuration.
+          <p>Synthesizes a specific text sent in the request with the provided configuration requirements
+and retrieves a response that includes the synthesized text as audio and the requested configuration.</p>
         
           <h4 id="ondewo.t2s.Text2Speech.BatchSynthesize" class="title-badge method">BatchSynthesize</h4>
 
           <pre>rpc BatchSynthesize (<a href="#ondewo.t2s.BatchSynthesizeRequest">BatchSynthesizeRequest</a>) returns (<a href="#ondewo.t2s.BatchSynthesizeResponse">BatchSynthesizeResponse)</a></pre>
 
-          BatchSynthesize RPC
-
-Performs batch synthesis by accepting a batch of synthesis requests and returning a batch response.
-This can be more efficient for generating predictions on the AI model in bulk.
+          <p>Performs batch synthesis by accepting a batch of synthesis requests and returning a batch response.
+This can be more efficient for generating predictions on the AI model in bulk.</p>
         
           <h4 id="ondewo.t2s.Text2Speech.StreamingSynthesize" class="title-badge method">StreamingSynthesize</h4>
 
           <pre>rpc StreamingSynthesize (stream <a href="#ondewo.t2s.StreamingSynthesizeRequest">StreamingSynthesizeRequest</a>) returns (stream <a href="#ondewo.t2s.StreamingSynthesizeResponse">StreamingSynthesizeResponse)</a></pre>
 
-          Performs streaming synthesis by accepting stream of input text and returning a stream of generated audio.
+          <p>Performs streaming synthesis by accepting stream of input text and returning a stream of generated audio.</p>
         
           <h4 id="ondewo.t2s.Text2Speech.NormalizeText" class="title-badge method">NormalizeText</h4>
 
           <pre>rpc NormalizeText (<a href="#ondewo.t2s.NormalizeTextRequest">NormalizeTextRequest</a>) returns (<a href="#ondewo.t2s.NormalizeTextResponse">NormalizeTextResponse)</a></pre>
 
-          NormalizeText RPC
-
-Normalizes a text according to the specific pipeline's normalization rules.
+          <p>Normalizes a text according to the specific pipeline&apos;s normalization rules.</p>
         
           <h4 id="ondewo.t2s.Text2Speech.GetT2sPipeline" class="title-badge method">GetT2sPipeline</h4>
 
           <pre>rpc GetT2sPipeline (<a href="#ondewo.t2s.T2sPipelineId">T2sPipelineId</a>) returns (<a href="#ondewo.t2s.Text2SpeechConfig">Text2SpeechConfig)</a></pre>
 
-          GetT2sPipeline RPC
-
-Retrieves the configuration of the specified text-to-speech pipeline.
+          <p>Retrieves the configuration of the specified text-to-speech pipeline.</p>
         
           <h4 id="ondewo.t2s.Text2Speech.CreateT2sPipeline" class="title-badge method">CreateT2sPipeline</h4>
 
           <pre>rpc CreateT2sPipeline (<a href="#ondewo.t2s.Text2SpeechConfig">Text2SpeechConfig</a>) returns (<a href="#ondewo.t2s.T2sPipelineId">T2sPipelineId)</a></pre>
 
-          CreateT2sPipeline RPC
-
-Creates a new text-to-speech pipeline with the provided configuration and returns its pipeline ID.
+          <p>Creates a new text-to-speech pipeline with the provided configuration and returns its pipeline ID.</p>
         
           <h4 id="ondewo.t2s.Text2Speech.DeleteT2sPipeline" class="title-badge method">DeleteT2sPipeline</h4>
 
           <pre>rpc DeleteT2sPipeline (<a href="#ondewo.t2s.T2sPipelineId">T2sPipelineId</a>) returns (<a href="#google.protobuf.Empty">.google.protobuf.Empty)</a></pre>
 
-          DeleteT2sPipeline RPC
-
-Deletes the specified text-to-speech pipeline.
+          <p>Deletes the specified text-to-speech pipeline.</p>
         
           <h4 id="ondewo.t2s.Text2Speech.UpdateT2sPipeline" class="title-badge method">UpdateT2sPipeline</h4>
 
           <pre>rpc UpdateT2sPipeline (<a href="#ondewo.t2s.Text2SpeechConfig">Text2SpeechConfig</a>) returns (<a href="#google.protobuf.Empty">.google.protobuf.Empty)</a></pre>
 
-          UpdateT2sPipeline RPC
-
-Updates the specified text-to-speech pipeline with the given configuration.
+          <p>Updates the specified text-to-speech pipeline with the given configuration.</p>
         
           <h4 id="ondewo.t2s.Text2Speech.ListT2sPipelines" class="title-badge method">ListT2sPipelines</h4>
 
           <pre>rpc ListT2sPipelines (<a href="#ondewo.t2s.ListT2sPipelinesRequest">ListT2sPipelinesRequest</a>) returns (<a href="#ondewo.t2s.ListT2sPipelinesResponse">ListT2sPipelinesResponse)</a></pre>
 
-          ListT2sPipelines RPC
-
-Retrieves a list of text-to-speech pipelines based on specific requirements.
+          <p>Retrieves a list of text-to-speech pipelines based on specific requirements.</p>
         
           <h4 id="ondewo.t2s.Text2Speech.ListT2sLanguages" class="title-badge method">ListT2sLanguages</h4>
 
           <pre>rpc ListT2sLanguages (<a href="#ondewo.t2s.ListT2sLanguagesRequest">ListT2sLanguagesRequest</a>) returns (<a href="#ondewo.t2s.ListT2sLanguagesResponse">ListT2sLanguagesResponse)</a></pre>
 
-          ListT2sLanguages RPC
-
-Retrieves a list of languages available based on specific configuration requirements.
+          <p>Retrieves a list of languages available based on specific configuration requirements.</p>
         
           <h4 id="ondewo.t2s.Text2Speech.ListT2sDomains" class="title-badge method">ListT2sDomains</h4>
 
           <pre>rpc ListT2sDomains (<a href="#ondewo.t2s.ListT2sDomainsRequest">ListT2sDomainsRequest</a>) returns (<a href="#ondewo.t2s.ListT2sDomainsResponse">ListT2sDomainsResponse)</a></pre>
 
-          ListT2sDomains RPC
-
-Retrieves a list of domains available based on specific configuration requirements.
+          <p>Retrieves a list of domains available based on specific configuration requirements.</p>
         
           <h4 id="ondewo.t2s.Text2Speech.ListT2sNormalizationPipelines" class="title-badge method">ListT2sNormalizationPipelines</h4>
 
           <pre>rpc ListT2sNormalizationPipelines (<a href="#ondewo.t2s.ListT2sNormalizationPipelinesRequest">ListT2sNormalizationPipelinesRequest</a>) returns (<a href="#ondewo.t2s.ListT2sNormalizationPipelinesResponse">ListT2sNormalizationPipelinesResponse)</a></pre>
 
-          ListT2sNormalizationPipelines RPC
-
-Retrieves a list of normalization pipelines based on specific requirements.
+          <p>Retrieves a list of normalization pipelines based on specific requirements.</p>
         
           <h4 id="ondewo.t2s.Text2Speech.GetServiceInfo" class="title-badge method">GetServiceInfo</h4>
 
           <pre>rpc GetServiceInfo (<a href="#google.protobuf.Empty">.google.protobuf.Empty</a>) returns (<a href="#ondewo.t2s.T2SGetServiceInfoResponse">T2SGetServiceInfoResponse)</a></pre>
 
-          GetServiceInfo RPC
-
-Retrieves the version information of the running text-to-speech server.
+          <p>Retrieves the version information of the running text-to-speech server.</p>
         
           <h4 id="ondewo.t2s.Text2Speech.GetCustomPhonemizer" class="title-badge method">GetCustomPhonemizer</h4>
 
           <pre>rpc GetCustomPhonemizer (<a href="#ondewo.t2s.PhonemizerId">PhonemizerId</a>) returns (<a href="#ondewo.t2s.CustomPhonemizerProto">CustomPhonemizerProto)</a></pre>
 
-          GetCustomPhonemizer RPC
-
-Retrieves a custom phonemizer based on the provided PhonemizerId.
+          <p>Retrieves a custom phonemizer based on the provided PhonemizerId.</p>
         
           <h4 id="ondewo.t2s.Text2Speech.CreateCustomPhonemizer" class="title-badge method">CreateCustomPhonemizer</h4>
 
           <pre>rpc CreateCustomPhonemizer (<a href="#ondewo.t2s.CreateCustomPhonemizerRequest">CreateCustomPhonemizerRequest</a>) returns (<a href="#ondewo.t2s.PhonemizerId">PhonemizerId)</a></pre>
 
-          CreateCustomPhonemizer RPC
-
-Creates a custom phonemizer based on the provided CreateCustomPhonemizerRequest.
-Returns the PhonemizerId associated with the created custom phonemizer.
+          <p>Creates a custom phonemizer based on the provided CreateCustomPhonemizerRequest.
+Returns the PhonemizerId associated with the created custom phonemizer.</p>
         
           <h4 id="ondewo.t2s.Text2Speech.DeleteCustomPhonemizer" class="title-badge method">DeleteCustomPhonemizer</h4>
 
           <pre>rpc DeleteCustomPhonemizer (<a href="#ondewo.t2s.PhonemizerId">PhonemizerId</a>) returns (<a href="#google.protobuf.Empty">.google.protobuf.Empty)</a></pre>
 
-          DeleteCustomPhonemizer RPC
-
-Deletes a custom phonemizer based on the provided PhonemizerId.
-Returns an Empty response upon successful deletion.
+          <p>Deletes a custom phonemizer based on the provided PhonemizerId.
+Returns an Empty response upon successful deletion.</p>
         
           <h4 id="ondewo.t2s.Text2Speech.UpdateCustomPhonemizer" class="title-badge method">UpdateCustomPhonemizer</h4>
 
           <pre>rpc UpdateCustomPhonemizer (<a href="#ondewo.t2s.UpdateCustomPhonemizerRequest">UpdateCustomPhonemizerRequest</a>) returns (<a href="#ondewo.t2s.CustomPhonemizerProto">CustomPhonemizerProto)</a></pre>
 
-          UpdateCustomPhonemizer RPC
-
-Updates the specified custom phonemizer with the provided configuration.
+          <p>Updates the specified custom phonemizer with the provided configuration.</p>
         
           <h4 id="ondewo.t2s.Text2Speech.ListCustomPhonemizer" class="title-badge method">ListCustomPhonemizer</h4>
 
           <pre>rpc ListCustomPhonemizer (<a href="#ondewo.t2s.ListCustomPhonemizerRequest">ListCustomPhonemizerRequest</a>) returns (<a href="#ondewo.t2s.ListCustomPhonemizerResponse">ListCustomPhonemizerResponse)</a></pre>
 
-          ListCustomPhonemizer RPC
-
-Retrieves a list of custom phonemizers based on specific requirements.
+          <p>Retrieves a list of custom phonemizers based on specific requirements.</p>
         
 
         
@@ -521,7 +487,7 @@ Retrieves a list of custom phonemizers based on specific requirements.
       <div id="ondewo/t2s/text-to-speech.proto-messages" class="object-category">Messages</div>
       
         <h3 id="ondewo.t2s.Apodization" class="title-badge message">Apodization</h3>
-        <p>Apodization message contains settings for apodization postprocessing.</p>
+        <p><p>Apodization message contains settings for apodization postprocessing.</p></p>
 
         
           <table class="field-table">
@@ -545,7 +511,7 @@ Retrieves a list of custom phonemizers based on specific requirements.
         
       
         <h3 id="ondewo.t2s.BatchSynthesizeRequest" class="title-badge message">BatchSynthesizeRequest</h3>
-        <p>BatchSynthesizeRequest message is used to send a batch request for synthesis.</p>
+        <p><p>BatchSynthesizeRequest message is used to send a batch request for synthesis.</p></p>
 
         
           <table class="field-table">
@@ -569,7 +535,7 @@ Retrieves a list of custom phonemizers based on specific requirements.
         
       
         <h3 id="ondewo.t2s.BatchSynthesizeResponse" class="title-badge message">BatchSynthesizeResponse</h3>
-        <p>BatchSynthesizeResponse message is used to store the responses for a batch synthesis request.</p>
+        <p><p>BatchSynthesizeResponse message is used to store the responses for a batch synthesis request.</p></p>
 
         
           <table class="field-table">
@@ -593,7 +559,7 @@ Retrieves a list of custom phonemizers based on specific requirements.
         
       
         <h3 id="ondewo.t2s.Caching" class="title-badge message">Caching</h3>
-        <p>Caching message contains settings for caching.</p>
+        <p><p>Caching message contains settings for caching.</p></p>
 
         
           <table class="field-table">
@@ -652,7 +618,7 @@ Retrieves a list of custom phonemizers based on specific requirements.
         
       
         <h3 id="ondewo.t2s.CompositeInference" class="title-badge message">CompositeInference</h3>
-        <p>CompositeInference message combines text-to-mel and mel-to-audio inference settings.</p>
+        <p><p>CompositeInference message combines text-to-mel and mel-to-audio inference settings.</p></p>
 
         
           <table class="field-table">
@@ -683,7 +649,7 @@ Retrieves a list of custom phonemizers based on specific requirements.
         
       
         <h3 id="ondewo.t2s.CreateCustomPhonemizerRequest" class="title-badge message">CreateCustomPhonemizerRequest</h3>
-        <p>CreateCustomPhonemizerRequest message represents the request for creating a custom phonemizer.</p>
+        <p><p>CreateCustomPhonemizerRequest message represents the request for creating a custom phonemizer.</p></p>
 
         
           <table class="field-table">
@@ -714,7 +680,7 @@ Retrieves a list of custom phonemizers based on specific requirements.
         
       
         <h3 id="ondewo.t2s.CustomPhonemizerProto" class="title-badge message">CustomPhonemizerProto</h3>
-        <p>CustomPhonemizerProto message represents a custom phonemizer.</p>
+        <p><p>CustomPhonemizerProto message represents a custom phonemizer.</p></p>
 
         
           <table class="field-table">
@@ -745,7 +711,7 @@ Retrieves a list of custom phonemizers based on specific requirements.
         
       
         <h3 id="ondewo.t2s.GlowTTS" class="title-badge message">GlowTTS</h3>
-        <p>GlowTTS message contains settings for the GlowTTS inference.</p>
+        <p><p>GlowTTS message contains settings for the GlowTTS inference.</p></p>
 
         
           <table class="field-table">
@@ -811,7 +777,7 @@ Retrieves a list of custom phonemizers based on specific requirements.
         
       
         <h3 id="ondewo.t2s.GlowTTSTriton" class="title-badge message">GlowTTSTriton</h3>
-        <p>GlowTTSTriton message contains settings for the GlowTTS Triton inference.</p>
+        <p><p>GlowTTSTriton message contains settings for the GlowTTS Triton inference.</p></p>
 
         
           <table class="field-table">
@@ -891,7 +857,7 @@ Retrieves a list of custom phonemizers based on specific requirements.
         
       
         <h3 id="ondewo.t2s.HiFiGan" class="title-badge message">HiFiGan</h3>
-        <p>HiFiGan message contains settings for the HiFiGan inference.</p>
+        <p><p>HiFiGan message contains settings for the HiFiGan inference.</p></p>
 
         
           <table class="field-table">
@@ -936,7 +902,7 @@ Retrieves a list of custom phonemizers based on specific requirements.
         
       
         <h3 id="ondewo.t2s.HiFiGanTriton" class="title-badge message">HiFiGanTriton</h3>
-        <p>HiFiGanTriton message contains settings for the HiFiGan Triton inference.</p>
+        <p><p>HiFiGanTriton message contains settings for the HiFiGan Triton inference.</p></p>
 
         
           <table class="field-table">
@@ -981,7 +947,7 @@ Retrieves a list of custom phonemizers based on specific requirements.
         
       
         <h3 id="ondewo.t2s.ListCustomPhonemizerRequest" class="title-badge message">ListCustomPhonemizerRequest</h3>
-        <p>ListCustomPhonemizerRequest message represents the request for listing custom phonemizers.</p>
+        <p><p>ListCustomPhonemizerRequest message represents the request for listing custom phonemizers.</p></p>
 
         
           <table class="field-table">
@@ -1005,7 +971,7 @@ Retrieves a list of custom phonemizers based on specific requirements.
         
       
         <h3 id="ondewo.t2s.ListCustomPhonemizerResponse" class="title-badge message">ListCustomPhonemizerResponse</h3>
-        <p>ListCustomPhonemizerResponse message represents the response for listing custom phonemizers.</p>
+        <p><p>ListCustomPhonemizerResponse message represents the response for listing custom phonemizers.</p></p>
 
         
           <table class="field-table">
@@ -1029,7 +995,7 @@ Retrieves a list of custom phonemizers based on specific requirements.
         
       
         <h3 id="ondewo.t2s.ListT2sDomainsRequest" class="title-badge message">ListT2sDomainsRequest</h3>
-        <p>Domain Request representation.</p><p>The request message for ListT2sDomains.</p><p>Filter domains of pipelines by attributed in request.</p>
+        <p><p>Domain Request representation.</p></p><p><p>The request message for ListT2sDomains.</p></p><p><p>Filter domains of pipelines by attributed in request.</p></p>
 
         
           <table class="field-table">
@@ -1074,7 +1040,7 @@ Retrieves a list of custom phonemizers based on specific requirements.
         
       
         <h3 id="ondewo.t2s.ListT2sDomainsResponse" class="title-badge message">ListT2sDomainsResponse</h3>
-        <p>Domains Response representation.</p><p>The response message for ListT2sDomains.</p>
+        <p><p>Domains Response representation.</p></p><p><p>The response message for ListT2sDomains.</p></p>
 
         
           <table class="field-table">
@@ -1099,7 +1065,7 @@ the specifications in the ListT2sDomainsRequest. </p></td>
         
       
         <h3 id="ondewo.t2s.ListT2sLanguagesRequest" class="title-badge message">ListT2sLanguagesRequest</h3>
-        <p>Language Request representation.</p><p>The request message for ListT2sLanguages.</p><p>Filter languages of pipelines by attributed in request.</p>
+        <p><p>Language Request representation.</p></p><p><p>The request message for ListT2sLanguages.</p></p><p><p>Filter languages of pipelines by attributed in request.</p></p>
 
         
           <table class="field-table">
@@ -1144,7 +1110,7 @@ the specifications in the ListT2sDomainsRequest. </p></td>
         
       
         <h3 id="ondewo.t2s.ListT2sLanguagesResponse" class="title-badge message">ListT2sLanguagesResponse</h3>
-        <p>Language Response representation.</p><p>The response message for ListT2sLanguages.</p>
+        <p><p>Language Response representation.</p></p><p><p>The response message for ListT2sLanguages.</p></p>
 
         
           <table class="field-table">
@@ -1169,7 +1135,7 @@ the specifications in the ListT2sLanguagesRequest. </p></td>
         
       
         <h3 id="ondewo.t2s.ListT2sNormalizationPipelinesRequest" class="title-badge message">ListT2sNormalizationPipelinesRequest</h3>
-        <p>The request message for ListT2sNormalizationPipelines.</p><p>Filter pipelines by attributed in request.</p>
+        <p><p>The request message for ListT2sNormalizationPipelines.</p></p><p><p>Filter pipelines by attributed in request.</p></p>
 
         
           <table class="field-table">
@@ -1193,7 +1159,7 @@ the specifications in the ListT2sLanguagesRequest. </p></td>
         
       
         <h3 id="ondewo.t2s.ListT2sNormalizationPipelinesResponse" class="title-badge message">ListT2sNormalizationPipelinesResponse</h3>
-        <p>Pipeline Response representation.</p><p>The response message for ListT2sNormalizationPipelines.</p>
+        <p><p>Pipeline Response representation.</p></p><p><p>The response message for ListT2sNormalizationPipelines.</p></p>
 
         
           <table class="field-table">
@@ -1219,7 +1185,7 @@ normalization pipelines with the specifications received in the ListT2sNormaliza
         
       
         <h3 id="ondewo.t2s.ListT2sPipelinesRequest" class="title-badge message">ListT2sPipelinesRequest</h3>
-        <p>Pipeline Request representation.</p><p>The request message for ListT2sPipelines.</p><p>Filter pipelines by attributed in request.</p>
+        <p><p>Pipeline Request representation.</p></p><p><p>The request message for ListT2sPipelines.</p></p><p><p>Filter pipelines by attributed in request.</p></p>
 
         
           <table class="field-table">
@@ -1271,7 +1237,7 @@ normalization pipelines with the specifications received in the ListT2sNormaliza
         
       
         <h3 id="ondewo.t2s.ListT2sPipelinesResponse" class="title-badge message">ListT2sPipelinesResponse</h3>
-        <p>Pipeline Response representation.</p><p>The response message for ListT2sPipelines.</p>
+        <p><p>Pipeline Response representation.</p></p><p><p>The response message for ListT2sPipelines.</p></p>
 
         
           <table class="field-table">
@@ -1297,7 +1263,7 @@ pipelines with the specifications received in the ListT2sPipelinesRequest. </p><
         
       
         <h3 id="ondewo.t2s.Logmnse" class="title-badge message">Logmnse</h3>
-        <p>Logmnse message contains settings for Logmnse postprocessing.</p>
+        <p><p>Logmnse message contains settings for Logmnse postprocessing.</p></p>
 
         
           <table class="field-table">
@@ -1335,7 +1301,7 @@ pipelines with the specifications received in the ListT2sPipelinesRequest. </p><
         
       
         <h3 id="ondewo.t2s.Map" class="title-badge message">Map</h3>
-        <p>Map message represents a word-to-phoneme mapping in a custom phonemizer.</p>
+        <p><p>Map message represents a word-to-phoneme mapping in a custom phonemizer.</p></p>
 
         
           <table class="field-table">
@@ -1366,7 +1332,7 @@ pipelines with the specifications received in the ListT2sPipelinesRequest. </p><
         
       
         <h3 id="ondewo.t2s.MbMelganTriton" class="title-badge message">MbMelganTriton</h3>
-        <p>MbMelganTriton message contains settings for the MbMelgan Triton inference.</p>
+        <p><p>MbMelganTriton message contains settings for the MbMelgan Triton inference.</p></p>
 
         
           <table class="field-table">
@@ -1418,7 +1384,7 @@ pipelines with the specifications received in the ListT2sPipelinesRequest. </p><
         
       
         <h3 id="ondewo.t2s.Mel2Audio" class="title-badge message">Mel2Audio</h3>
-        <p>Mel2Audio message contains settings for mel-to-audio inference.</p>
+        <p><p>Mel2Audio message contains settings for mel-to-audio inference.</p></p>
 
         
           <table class="field-table">
@@ -1463,7 +1429,7 @@ pipelines with the specifications received in the ListT2sPipelinesRequest. </p><
         
       
         <h3 id="ondewo.t2s.NormalizeTextRequest" class="title-badge message">NormalizeTextRequest</h3>
-        <p>NormalizeTextRequest message is used to request text normalization.</p>
+        <p><p>NormalizeTextRequest message is used to request text normalization.</p></p>
 
         
           <table class="field-table">
@@ -1494,7 +1460,7 @@ pipelines with the specifications received in the ListT2sPipelinesRequest. </p><
         
       
         <h3 id="ondewo.t2s.NormalizeTextResponse" class="title-badge message">NormalizeTextResponse</h3>
-        <p>NormalizeTextResponse message is used to store the normalized text response.</p>
+        <p><p>NormalizeTextResponse message is used to store the normalized text response.</p></p>
 
         
           <table class="field-table">
@@ -1518,7 +1484,7 @@ pipelines with the specifications received in the ListT2sPipelinesRequest. </p><
         
       
         <h3 id="ondewo.t2s.PhonemizerId" class="title-badge message">PhonemizerId</h3>
-        <p>PhonemizerId message represents the ID of a phonemizer.</p>
+        <p><p>PhonemizerId message represents the ID of a phonemizer.</p></p>
 
         
           <table class="field-table">
@@ -1542,7 +1508,7 @@ pipelines with the specifications received in the ListT2sPipelinesRequest. </p><
         
       
         <h3 id="ondewo.t2s.Postprocessing" class="title-badge message">Postprocessing</h3>
-        <p>Postprocessing message contains settings for postprocessing.</p>
+        <p><p>Postprocessing message contains settings for postprocessing.</p></p>
 
         
           <table class="field-table">
@@ -1594,7 +1560,7 @@ pipelines with the specifications received in the ListT2sPipelinesRequest. </p><
         
       
         <h3 id="ondewo.t2s.RequestConfig" class="title-badge message">RequestConfig</h3>
-        <p>Represents a Configuration for the text to speech conversion.</p>
+        <p><p>Represents a Configuration for the text to speech conversion.</p></p>
 
         
           <table class="field-table">
@@ -1666,31 +1632,42 @@ The default value is False. </p></td>
                   <td><a href="#google.protobuf.Struct">google.protobuf.Struct</a></td>
                   <td>optional</td>
                   <td><p>Optional. t2s_service_config provides the configuration of the service such as API key, bearer tokens, JWT,
-and other header information as key value pairs, e.g., <pre><code>MY_API_KEY='LKJDIFe244LKJOI'</code></pre>
+and other header information as key value pairs, e.g., <pre><code>MY_API_KEY=&apos;LKJDIFe244LKJOI&apos;</code></pre>
+
 A. For Amazon T2S service, the following arguments should be passed:
-  A1. aws_access_key_id (required) Access key id to access Amazon WEB Service.
-  A2. aws_secret_access_key (required) Secret access key to access Amazon WEB Service.
-  A3. region (required) Region name of Amazon Server.
-  Example:
-  t2s_config_service={'aws_access_key_id': 'YOUR_AWS_ACCESS_KEY_ID', 'aws_secret_access_key':
- 'YOUR_AWS_SECRET_ACCESS_KEY', 'region': 'YOUR_AMAZON_SERVER_REGION_NAME'}
+<ul>
+  <li>A1. <code>aws_access_key_id</code> (required) Access key id to access Amazon WEB Service.</li>
+  <li>A2. <code>aws_secret_access_key</code> (required) Secret access key to access Amazon WEB Service.</li>
+  <li>A3. <code>region</code> (required) Region name of Amazon Server.</li>
+</ul>
+Example:
+<pre><code>t2s_config_service={&apos;aws_access_key_id&apos;: &apos;YOUR_AWS_ACCESS_KEY_ID&apos;, &apos;aws_secret_access_key&apos;: &apos;YOUR_AWS_SECRET_ACCESS_KEY&apos;, &apos;region&apos;: &apos;YOUR_AMAZON_SERVER_REGION_NAME&apos;}</code></pre>
+
 B. For ElevenLabs T2s service, the following arguments should be passed:
-  B1. api_key (required) API key of ElevenLabs cloud provider to access its T2S service.
-  Example:
-  t2s_config_service={'api_key': 'YOUR_ELEVENLABS_API_KEY'}
+<ul>
+  <li>B1. <code>api_key</code> (required) API key of ElevenLabs cloud provider to access its T2S service.</li>
+</ul>
+Example:
+<pre><code>t2s_config_service={&apos;api_key&apos;: &apos;YOUR_ELEVENLABS_API_KEY&apos;}</code></pre>
+
 C. For Google cloud T2S service, the following arguments should be passed:
-  C1. api_key (required) API key of Google cloud provider to access its T2S service.
-  C2. api_endpoint (optional) Regional API endpoint of Google cloud T2S service.
-    (Defaults to 'eu-texttospeech.googleapis.com')
-  Example:
-  t2s_config_service={'api_key': 'YOUR_GOOGLE_CLOUD_API_KEY', 'api_endpoint': 'YOUR_GOOGLE_CLOUD_API_ENDPOINT'}
+<ul>
+  <li>C1. <code>api_key</code> (required) API key of Google cloud provider to access its T2S service.</li>
+  <li>C2. <code>api_endpoint</code> (optional) Regional API endpoint of Google cloud T2S service.
+    (Defaults to &apos;eu-texttospeech.googleapis.com&apos;)</li>
+</ul>
+Example:
+<pre><code>t2s_config_service={&apos;api_key&apos;: &apos;YOUR_GOOGLE_CLOUD_API_KEY&apos;, &apos;api_endpoint&apos;: &apos;YOUR_GOOGLE_CLOUD_API_ENDPOINT&apos;}</code></pre>
+
 D. For Microsoft Azure T2s service, the following arguments should be passed:
-  D1. subscription_key (required) Subscription key to access Microsoft Azure Service.
-  D2. region (required) Region name of Microsoft Azure Server.
-  Example:
-  t2s_config_service={'subscription_key': 'YOUR_MICROSOFT_AZURE_SUBSCRIPTION_KEY', 'region':
-  'YOUR_MICROSOFT_AZURE_SERVER_REGION_NAME'}
-Note: ondewo-t2s will raise an error if you don't pass any of the required arguments above. </p></td>
+<ul>
+  <li>D1. <code>subscription_key</code> (required) Subscription key to access Microsoft Azure Service.</li>
+  <li>D2. <code>region</code> (required) Region name of Microsoft Azure Server.</li>
+</ul>
+Example:
+<pre><code>t2s_config_service={&apos;subscription_key&apos;: &apos;YOUR_MICROSOFT_AZURE_SUBSCRIPTION_KEY&apos;, &apos;region&apos;: &apos;YOUR_MICROSOFT_AZURE_SERVER_REGION_NAME&apos;}</code></pre>
+
+Note: ondewo-t2s will raise an error if you don&apos;t pass any of the required arguments above. </p></td>
                 </tr>
               
                 <tr>
@@ -1725,7 +1702,7 @@ this specific request and will not update the pipeline. </p></td>
         
       
         <h3 id="ondewo.t2s.SingleInference" class="title-badge message">SingleInference</h3>
-        <p>SingleInference message inference settings of text2audio models.</p>
+        <p><p>SingleInference message inference settings of text2audio models.</p></p>
 
         
           <table class="field-table">
@@ -1749,7 +1726,7 @@ this specific request and will not update the pipeline. </p></td>
         
       
         <h3 id="ondewo.t2s.StreamingSynthesizeRequest" class="title-badge message">StreamingSynthesizeRequest</h3>
-        <p>StreamingSynthesizeRequest is used to perform streaming synthesize.</p>
+        <p><p>StreamingSynthesizeRequest is used to perform streaming synthesize.</p></p>
 
         
           <table class="field-table">
@@ -1781,7 +1758,7 @@ All the properties according to the input text in SynthesizeRequest can be also 
         
       
         <h3 id="ondewo.t2s.StreamingSynthesizeResponse" class="title-badge message">StreamingSynthesizeResponse</h3>
-        <p>Represents a Streaming Synthesize Response.</p><p>A Streaming Synthesize Response contains the generated audio, requested text and and</p><p>all other properties of this generated audio.</p>
+        <p><p>Represents a Streaming Synthesize Response.</p></p><p><p>A Streaming Synthesize Response contains the generated audio, requested text and and</p><p>all other properties of this generated audio.</p></p>
 
         
           <table class="field-table">
@@ -1854,7 +1831,7 @@ All the properties according to the input text in SynthesizeRequest can be also 
         
       
         <h3 id="ondewo.t2s.SynthesizeRequest" class="title-badge message">SynthesizeRequest</h3>
-        <p>Represents a Synthesize Request.</p><p>A Synthesize Request contains the information need to perform a text to speech conversion.</p>
+        <p><p>Represents a Synthesize Request.</p></p><p><p>A Synthesize Request contains the information need to perform a text to speech conversion.</p></p>
 
         
           <table class="field-table">
@@ -1868,30 +1845,22 @@ All the properties according to the input text in SynthesizeRequest can be also 
                   <td><a href="#string">string</a></td>
                   <td></td>
                   <td><p>Required. Represents the text that will be transformed to speech.
-
-<p> Synthesize text: </p>
-
-- Simple text: <pre><code>Hello, how are you?</code></pre>
-
-<p>Examples to modulate the voice based on SSML tags and Arpabet phonemes:</p>
-
-- SSML Tag Phone: <pre><code>&lt;say-as interpret-as="phone">+12354321&lt;/say-as&gt;</code></pre>
-
-- SSML Tag Email: <pre><code>&lt;say-as interpret-as="email">voices@ondewo.com&lt;/say-as&gt;</code></pre>
-
-- SSML Tag URL: <pre><code>&lt;say-as interpret-as="url">ondewo.com/en/&lt;/say-as&gt;</code></pre>
-
-- SSML Tag Spell: <pre><code>&lt;say-as interpret-as="spell">AP732&lt;/say-as&gt;</code></pre>
-
-- SSML Tag Spell With Names: <pre><code>&lt;say-as interpret-as="spell-with-names">AHO32&lt;/say-as&gt;</code></pre>
-
-- SSML Tag Callsigns Short: <pre><code>&lt;say-as interpret-as="callsign-short">AUA439&lt;/say-as&gt;</code></pre>
-
-- SSML Tag Callsigns Long: <pre><code>&lt;say-as interpret-as="callsign-long">AAL439&lt;/say-as&gt;</code></pre>
-
-- SSML Tag Break Tag: <pre><code>I am going to take a 2 seconds break <break time="2.0"/> done</code></pre>
-
-- Arpabet Phonemes: <pre><code>Hello I am {AE2 L EH0 G Z AE1 N D R AH0}</code></pre> </p></td>
+Synthesize text:
+<ul>
+  <li>Simple text: <pre><code>Hello, how are you?</code></pre></li>
+</ul>
+Examples to modulate the voice based on SSML tags and Arpabet phonemes:
+<ul>
+  <li>SSML Tag Phone: <pre><code>&lt;say-as interpret-as=&quot;phone&quot;&gt;+12354321&lt;/say-as&gt;</code></pre></li>
+  <li>SSML Tag Email: <pre><code>&lt;say-as interpret-as=&quot;email&quot;&gt;voices@ondewo.com&lt;/say-as&gt;</code></pre></li>
+  <li>SSML Tag URL: <pre><code>&lt;say-as interpret-as=&quot;url&quot;&gt;ondewo.com/en/&lt;/say-as&gt;</code></pre></li>
+  <li>SSML Tag Spell: <pre><code>&lt;say-as interpret-as=&quot;spell&quot;&gt;AP732&lt;/say-as&gt;</code></pre></li>
+  <li>SSML Tag Spell With Names: <pre><code>&lt;say-as interpret-as=&quot;spell-with-names&quot;&gt;AHO32&lt;/say-as&gt;</code></pre></li>
+  <li>SSML Tag Callsigns Short: <pre><code>&lt;say-as interpret-as=&quot;callsign-short&quot;&gt;AUA439&lt;/say-as&gt;</code></pre></li>
+  <li>SSML Tag Callsigns Long: <pre><code>&lt;say-as interpret-as=&quot;callsign-long&quot;&gt;AAL439&lt;/say-as&gt;</code></pre></li>
+  <li>SSML Tag Break Tag: <pre><code>I am going to take a 2 seconds break &lt;break time=&quot;2.0&quot;/&gt; done</code></pre></li>
+  <li>Arpabet Phonemes: <pre><code>Hello I am {AE2 L EH0 G Z AE1 N D R AH0}</code></pre></li>
+</ul> </p></td>
                 </tr>
               
                 <tr>
@@ -1909,7 +1878,7 @@ All the properties according to the input text in SynthesizeRequest can be also 
         
       
         <h3 id="ondewo.t2s.SynthesizeResponse" class="title-badge message">SynthesizeResponse</h3>
-        <p>Represents a Synthesize Response.</p><p>A Synthesize Response contains the generated audio, requested text and all other properties of this generated audio.</p>
+        <p><p>Represents a Synthesize Response.</p></p><p><p>A Synthesize Response contains the generated audio, requested text and all other properties of this generated audio.</p></p>
 
         
           <table class="field-table">
@@ -1982,7 +1951,7 @@ All the properties according to the input text in SynthesizeRequest can be also 
         
       
         <h3 id="ondewo.t2s.T2SCustomLengthScales" class="title-badge message">T2SCustomLengthScales</h3>
-        <p>T2SCustomLengthScales message contains custom length scales for text types.</p>
+        <p><p>T2SCustomLengthScales message contains custom length scales for text types.</p></p>
 
         
           <table class="field-table">
@@ -2055,7 +2024,7 @@ All the properties according to the input text in SynthesizeRequest can be also 
         
       
         <h3 id="ondewo.t2s.T2SDescription" class="title-badge message">T2SDescription</h3>
-        <p>T2SDescription message is used to describe the text-to-speech service.</p>
+        <p><p>T2SDescription message is used to describe the text-to-speech service.</p></p>
 
         
           <table class="field-table">
@@ -2114,7 +2083,7 @@ All the properties according to the input text in SynthesizeRequest can be also 
         
       
         <h3 id="ondewo.t2s.T2SGetServiceInfoResponse" class="title-badge message">T2SGetServiceInfoResponse</h3>
-        <p>Version information of the service</p>
+        <p><p>Version information of the service</p></p>
 
         
           <table class="field-table">
@@ -2138,7 +2107,7 @@ All the properties according to the input text in SynthesizeRequest can be also 
         
       
         <h3 id="ondewo.t2s.T2SInference" class="title-badge message">T2SInference</h3>
-        <p>T2SInference message is used to specify the text-to-speech inference settings.</p>
+        <p><p>T2SInference message is used to specify the text-to-speech inference settings.</p></p>
 
         
           <table class="field-table">
@@ -2183,7 +2152,7 @@ All the properties according to the input text in SynthesizeRequest can be also 
         
       
         <h3 id="ondewo.t2s.T2SNormalization" class="title-badge message">T2SNormalization</h3>
-        <p>Represents the configuration for text-to-speech normalization.</p>
+        <p><p>Represents the configuration for text-to-speech normalization.</p></p>
 
         
           <table class="field-table">
@@ -2256,7 +2225,7 @@ All the properties according to the input text in SynthesizeRequest can be also 
         
       
         <h3 id="ondewo.t2s.T2sCloudProviderConfig" class="title-badge message">T2sCloudProviderConfig</h3>
-        <p>Configuration for cloud provider settings for Text-to-Speech (T2S).</p>
+        <p><p>Configuration for cloud provider settings for Text-to-Speech (T2S).</p></p>
 
         
           <table class="field-table">
@@ -2294,7 +2263,7 @@ All the properties according to the input text in SynthesizeRequest can be also 
         
       
         <h3 id="ondewo.t2s.T2sCloudProviderConfigElevenLabs" class="title-badge message">T2sCloudProviderConfigElevenLabs</h3>
-        <p>Configuration details specific to the Eleven Labs text-to-speech provider.</p>
+        <p><p>Configuration details specific to the Eleven Labs text-to-speech provider.</p></p>
 
         
           <table class="field-table">
@@ -2347,7 +2316,7 @@ It is in the range [0.0, 1.0]. </p></td>
         
       
         <h3 id="ondewo.t2s.T2sCloudProviderConfigGoogle" class="title-badge message">T2sCloudProviderConfigGoogle</h3>
-        <p>Configuration details specific to the Google text-to-speech provider.</p>
+        <p><p>Configuration details specific to the Google text-to-speech provider.</p></p>
 
         
           <table class="field-table">
@@ -2385,7 +2354,7 @@ It is in the range [0.0, 1.0]. </p></td>
         
       
         <h3 id="ondewo.t2s.T2sCloudProviderConfigMicrosoft" class="title-badge message">T2sCloudProviderConfigMicrosoft</h3>
-        <p>Configuration details specific to the Microsoft text-to-speech provider.</p>
+        <p><p>Configuration details specific to the Microsoft text-to-speech provider.</p></p>
 
         
           <table class="field-table">
@@ -2409,7 +2378,7 @@ It is in the range [0.0, 1.0]. </p></td>
         
       
         <h3 id="ondewo.t2s.T2sCloudServiceAmazon" class="title-badge message">T2sCloudServiceAmazon</h3>
-        <p>T2sCloudServiceAmazon message contains settings for the Amazon Cloud service inference.</p>
+        <p><p>T2sCloudServiceAmazon message contains settings for the Amazon Cloud service inference.</p></p>
 
         
           <table class="field-table">
@@ -2440,7 +2409,7 @@ It is in the range [0.0, 1.0]. </p></td>
         
       
         <h3 id="ondewo.t2s.T2sCloudServiceElevenLabs" class="title-badge message">T2sCloudServiceElevenLabs</h3>
-        <p>T2sCloudServiceElevenLabs message contains settings for the ElevenLabs Cloud service inference.</p>
+        <p><p>T2sCloudServiceElevenLabs message contains settings for the ElevenLabs Cloud service inference.</p></p>
 
         
           <table class="field-table">
@@ -2492,7 +2461,7 @@ It is in the range [0.0, 1.0]. </p></td>
         
       
         <h3 id="ondewo.t2s.T2sCloudServiceGoogle" class="title-badge message">T2sCloudServiceGoogle</h3>
-        <p>T2sCloudServiceGoogle message contains settings for the Google Cloud service inference.</p>
+        <p><p>T2sCloudServiceGoogle message contains settings for the Google Cloud service inference.</p></p>
 
         
           <table class="field-table">
@@ -2537,7 +2506,7 @@ It is in the range [0.0, 1.0]. </p></td>
         
       
         <h3 id="ondewo.t2s.T2sCloudServiceMicrosoft" class="title-badge message">T2sCloudServiceMicrosoft</h3>
-        <p>T2sCloudServiceMicrosoft message contains settings for the Microsoft Cloud service inference.</p>
+        <p><p>T2sCloudServiceMicrosoft message contains settings for the Microsoft Cloud service inference.</p></p>
 
         
           <table class="field-table">
@@ -2568,7 +2537,7 @@ It is in the range [0.0, 1.0]. </p></td>
         
       
         <h3 id="ondewo.t2s.T2sPipelineId" class="title-badge message">T2sPipelineId</h3>
-        <p>Pipeline Id representation.</p><p>Used in the creation, deletion and getter of pipelines.</p>
+        <p><p>Pipeline Id representation.</p></p><p><p>Used in the creation, deletion and getter of pipelines.</p></p>
 
         
           <table class="field-table">
@@ -2592,7 +2561,7 @@ It is in the range [0.0, 1.0]. </p></td>
         
       
         <h3 id="ondewo.t2s.Text2Audio" class="title-badge message">Text2Audio</h3>
-        <p>Text2Audio message contains settings for text-to-audio inference.</p>
+        <p><p>Text2Audio message contains settings for text-to-audio inference.</p></p>
 
         
           <table class="field-table">
@@ -2658,7 +2627,7 @@ It is in the range [0.0, 1.0]. </p></td>
         
       
         <h3 id="ondewo.t2s.Text2Mel" class="title-badge message">Text2Mel</h3>
-        <p>Text2Mel message contains settings for text-to-mel inference.</p>
+        <p><p>Text2Mel message contains settings for text-to-mel inference.</p></p>
 
         
           <table class="field-table">
@@ -2696,7 +2665,7 @@ It is in the range [0.0, 1.0]. </p></td>
         
       
         <h3 id="ondewo.t2s.Text2SpeechConfig" class="title-badge message">Text2SpeechConfig</h3>
-        <p>Configuration of text-to-speech models representation.</p>
+        <p><p>Configuration of text-to-speech models representation.</p></p>
 
         
           <table class="field-table">
@@ -2755,7 +2724,7 @@ It is in the range [0.0, 1.0]. </p></td>
         
       
         <h3 id="ondewo.t2s.UpdateCustomPhonemizerRequest" class="title-badge message">UpdateCustomPhonemizerRequest</h3>
-        <p>UpdateCustomPhonemizerRequest message represents the request for updating a custom phonemizer.</p>
+        <p><p>UpdateCustomPhonemizerRequest message represents the request for updating a custom phonemizer.</p></p>
 
         
           <table class="field-table">
@@ -2793,7 +2762,7 @@ It is in the range [0.0, 1.0]. </p></td>
         
       
         <h3 id="ondewo.t2s.Vits" class="title-badge message">Vits</h3>
-        <p></p>
+        <p><p>Vits message contains settings for the Vits inference.</p></p>
 
         
           <table class="field-table">
@@ -2859,7 +2828,7 @@ It is in the range [0.0, 1.0]. </p></td>
         
       
         <h3 id="ondewo.t2s.VitsTriton" class="title-badge message">VitsTriton</h3>
-        <p>VitsTriton message contains settings for the Vits Triton inference.</p>
+        <p><p>VitsTriton message contains settings for the Vits Triton inference.</p></p>
 
         
           <table class="field-table">
@@ -2939,7 +2908,7 @@ It is in the range [0.0, 1.0]. </p></td>
         
       
         <h3 id="ondewo.t2s.VoiceSettings" class="title-badge message">VoiceSettings</h3>
-        <p>VoiceSettings message contains settings for ElevenLabs inference.</p>
+        <p><p>VoiceSettings message contains settings for ElevenLabs inference.</p></p>
 
         
           <table class="field-table">
@@ -2984,7 +2953,7 @@ It is in the range [0.0, 1.0]. </p></td>
         
       
         <h3 id="ondewo.t2s.Wiener" class="title-badge message">Wiener</h3>
-        <p>Wiener message contains settings for Wiener postprocessing.</p>
+        <p><p>Wiener message contains settings for Wiener postprocessing.</p></p>
 
         
           <table class="field-table">
@@ -3041,7 +3010,7 @@ It is in the range [0.0, 1.0]. </p></td>
       <div id="ondewo/t2s/text-to-speech.proto-enums" class="object-category">Enums</div>
       
         <h3 id="ondewo.t2s.AudioFormat" class="title-badge enum">AudioFormat</h3>
-        <p>AudioFormat enum represents various audio file formats for storing digital audio data.</p>
+        <p><p>AudioFormat enum represents various audio file formats for storing digital audio data.</p></p>
         <table class="enum-table">
           <thead>
             <tr><td>Name</td><td>Number</td><td>Description</td></tr>
@@ -3094,7 +3063,7 @@ It is in the range [0.0, 1.0]. </p></td>
         </table>
       
         <h3 id="ondewo.t2s.Pcm" class="title-badge enum">Pcm</h3>
-        <p>Represents a pulse-code modulation technique.</p>
+        <p><p>Represents a pulse-code modulation technique.</p></p>
         <table class="enum-table">
           <thead>
             <tr><td>Name</td><td>Number</td><td>Description</td></tr>

--- a/docs/index.md
+++ b/docs/index.md
@@ -1154,6 +1154,7 @@ all other properties of this generated audio.</p>
 
 ### UpdateCustomPhonemizerRequest.UpdateMethod
 The update method to be used.
+UpdateMethod enum defines the method for updating custom phonemizers.
 
 | Name | Number | Description |
 | ---- | ------ | ----------- |

--- a/docs/index.md
+++ b/docs/index.md
@@ -82,7 +82,7 @@
 <a name="ondewo.t2s.Apodization"></a>
 
 ### Apodization
-Apodization message contains settings for apodization postprocessing.
+<p>Apodization message contains settings for apodization postprocessing.</p>
 
 
 | Field | Type | Label | Description |
@@ -97,7 +97,7 @@ Apodization message contains settings for apodization postprocessing.
 <a name="ondewo.t2s.BatchSynthesizeRequest"></a>
 
 ### BatchSynthesizeRequest
-BatchSynthesizeRequest message is used to send a batch request for synthesis.
+<p>BatchSynthesizeRequest message is used to send a batch request for synthesis.</p>
 
 
 | Field | Type | Label | Description |
@@ -112,7 +112,7 @@ BatchSynthesizeRequest message is used to send a batch request for synthesis.
 <a name="ondewo.t2s.BatchSynthesizeResponse"></a>
 
 ### BatchSynthesizeResponse
-BatchSynthesizeResponse message is used to store the responses for a batch synthesis request.
+<p>BatchSynthesizeResponse message is used to store the responses for a batch synthesis request.</p>
 
 
 | Field | Type | Label | Description |
@@ -127,7 +127,7 @@ BatchSynthesizeResponse message is used to store the responses for a batch synth
 <a name="ondewo.t2s.Caching"></a>
 
 ### Caching
-Caching message contains settings for caching.
+<p>Caching message contains settings for caching.</p>
 
 
 | Field | Type | Label | Description |
@@ -147,7 +147,7 @@ Caching message contains settings for caching.
 <a name="ondewo.t2s.CompositeInference"></a>
 
 ### CompositeInference
-CompositeInference message combines text-to-mel and mel-to-audio inference settings.
+<p>CompositeInference message combines text-to-mel and mel-to-audio inference settings.</p>
 
 
 | Field | Type | Label | Description |
@@ -163,7 +163,7 @@ CompositeInference message combines text-to-mel and mel-to-audio inference setti
 <a name="ondewo.t2s.CreateCustomPhonemizerRequest"></a>
 
 ### CreateCustomPhonemizerRequest
-CreateCustomPhonemizerRequest message represents the request for creating a custom phonemizer.
+<p>CreateCustomPhonemizerRequest message represents the request for creating a custom phonemizer.</p>
 
 
 | Field | Type | Label | Description |
@@ -179,7 +179,7 @@ CreateCustomPhonemizerRequest message represents the request for creating a cust
 <a name="ondewo.t2s.CustomPhonemizerProto"></a>
 
 ### CustomPhonemizerProto
-CustomPhonemizerProto message represents a custom phonemizer.
+<p>CustomPhonemizerProto message represents a custom phonemizer.</p>
 
 
 | Field | Type | Label | Description |
@@ -195,7 +195,7 @@ CustomPhonemizerProto message represents a custom phonemizer.
 <a name="ondewo.t2s.GlowTTS"></a>
 
 ### GlowTTS
-GlowTTS message contains settings for the GlowTTS inference.
+<p>GlowTTS message contains settings for the GlowTTS inference.</p>
 
 
 | Field | Type | Label | Description |
@@ -216,7 +216,7 @@ GlowTTS message contains settings for the GlowTTS inference.
 <a name="ondewo.t2s.GlowTTSTriton"></a>
 
 ### GlowTTSTriton
-GlowTTSTriton message contains settings for the GlowTTS Triton inference.
+<p>GlowTTSTriton message contains settings for the GlowTTS Triton inference.</p>
 
 
 | Field | Type | Label | Description |
@@ -239,7 +239,7 @@ GlowTTSTriton message contains settings for the GlowTTS Triton inference.
 <a name="ondewo.t2s.HiFiGan"></a>
 
 ### HiFiGan
-HiFiGan message contains settings for the HiFiGan inference.
+<p>HiFiGan message contains settings for the HiFiGan inference.</p>
 
 
 | Field | Type | Label | Description |
@@ -257,7 +257,7 @@ HiFiGan message contains settings for the HiFiGan inference.
 <a name="ondewo.t2s.HiFiGanTriton"></a>
 
 ### HiFiGanTriton
-HiFiGanTriton message contains settings for the HiFiGan Triton inference.
+<p>HiFiGanTriton message contains settings for the HiFiGan Triton inference.</p>
 
 
 | Field | Type | Label | Description |
@@ -275,7 +275,7 @@ HiFiGanTriton message contains settings for the HiFiGan Triton inference.
 <a name="ondewo.t2s.ListCustomPhonemizerRequest"></a>
 
 ### ListCustomPhonemizerRequest
-ListCustomPhonemizerRequest message represents the request for listing custom phonemizers.
+<p>ListCustomPhonemizerRequest message represents the request for listing custom phonemizers.</p>
 
 
 | Field | Type | Label | Description |
@@ -290,7 +290,7 @@ ListCustomPhonemizerRequest message represents the request for listing custom ph
 <a name="ondewo.t2s.ListCustomPhonemizerResponse"></a>
 
 ### ListCustomPhonemizerResponse
-ListCustomPhonemizerResponse message represents the response for listing custom phonemizers.
+<p>ListCustomPhonemizerResponse message represents the response for listing custom phonemizers.</p>
 
 
 | Field | Type | Label | Description |
@@ -305,9 +305,9 @@ ListCustomPhonemizerResponse message represents the response for listing custom 
 <a name="ondewo.t2s.ListT2sDomainsRequest"></a>
 
 ### ListT2sDomainsRequest
-Domain Request representation.
-The request message for ListT2sDomains.
-Filter domains of pipelines by attributed in request.
+<p>Domain Request representation.</p>
+<p>The request message for ListT2sDomains.</p>
+<p>Filter domains of pipelines by attributed in request.</p>
 
 
 | Field | Type | Label | Description |
@@ -325,8 +325,8 @@ Filter domains of pipelines by attributed in request.
 <a name="ondewo.t2s.ListT2sDomainsResponse"></a>
 
 ### ListT2sDomainsResponse
-Domains Response representation.
-The response message for ListT2sDomains.
+<p>Domains Response representation.</p>
+<p>The response message for ListT2sDomains.</p>
 
 
 | Field | Type | Label | Description |
@@ -341,9 +341,9 @@ The response message for ListT2sDomains.
 <a name="ondewo.t2s.ListT2sLanguagesRequest"></a>
 
 ### ListT2sLanguagesRequest
-Language Request representation.
-The request message for ListT2sLanguages.
-Filter languages of pipelines by attributed in request.
+<p>Language Request representation.</p>
+<p>The request message for ListT2sLanguages.</p>
+<p>Filter languages of pipelines by attributed in request.</p>
 
 
 | Field | Type | Label | Description |
@@ -361,8 +361,8 @@ Filter languages of pipelines by attributed in request.
 <a name="ondewo.t2s.ListT2sLanguagesResponse"></a>
 
 ### ListT2sLanguagesResponse
-Language Response representation.
-The response message for ListT2sLanguages.
+<p>Language Response representation.</p>
+<p>The response message for ListT2sLanguages.</p>
 
 
 | Field | Type | Label | Description |
@@ -377,8 +377,8 @@ The response message for ListT2sLanguages.
 <a name="ondewo.t2s.ListT2sNormalizationPipelinesRequest"></a>
 
 ### ListT2sNormalizationPipelinesRequest
-The request message for ListT2sNormalizationPipelines.
-Filter pipelines by attributed in request.
+<p>The request message for ListT2sNormalizationPipelines.</p>
+<p>Filter pipelines by attributed in request.</p>
 
 
 | Field | Type | Label | Description |
@@ -393,8 +393,8 @@ Filter pipelines by attributed in request.
 <a name="ondewo.t2s.ListT2sNormalizationPipelinesResponse"></a>
 
 ### ListT2sNormalizationPipelinesResponse
-Pipeline Response representation.
-The response message for ListT2sNormalizationPipelines.
+<p>Pipeline Response representation.</p>
+<p>The response message for ListT2sNormalizationPipelines.</p>
 
 
 | Field | Type | Label | Description |
@@ -409,9 +409,9 @@ The response message for ListT2sNormalizationPipelines.
 <a name="ondewo.t2s.ListT2sPipelinesRequest"></a>
 
 ### ListT2sPipelinesRequest
-Pipeline Request representation.
-The request message for ListT2sPipelines.
-Filter pipelines by attributed in request.
+<p>Pipeline Request representation.</p>
+<p>The request message for ListT2sPipelines.</p>
+<p>Filter pipelines by attributed in request.</p>
 
 
 | Field | Type | Label | Description |
@@ -430,8 +430,8 @@ Filter pipelines by attributed in request.
 <a name="ondewo.t2s.ListT2sPipelinesResponse"></a>
 
 ### ListT2sPipelinesResponse
-Pipeline Response representation.
-The response message for ListT2sPipelines.
+<p>Pipeline Response representation.</p>
+<p>The response message for ListT2sPipelines.</p>
 
 
 | Field | Type | Label | Description |
@@ -446,7 +446,7 @@ The response message for ListT2sPipelines.
 <a name="ondewo.t2s.Logmnse"></a>
 
 ### Logmnse
-Logmnse message contains settings for Logmnse postprocessing.
+<p>Logmnse message contains settings for Logmnse postprocessing.</p>
 
 
 | Field | Type | Label | Description |
@@ -463,7 +463,7 @@ Logmnse message contains settings for Logmnse postprocessing.
 <a name="ondewo.t2s.Map"></a>
 
 ### Map
-Map message represents a word-to-phoneme mapping in a custom phonemizer.
+<p>Map message represents a word-to-phoneme mapping in a custom phonemizer.</p>
 
 
 | Field | Type | Label | Description |
@@ -479,7 +479,7 @@ Map message represents a word-to-phoneme mapping in a custom phonemizer.
 <a name="ondewo.t2s.MbMelganTriton"></a>
 
 ### MbMelganTriton
-MbMelganTriton message contains settings for the MbMelgan Triton inference.
+<p>MbMelganTriton message contains settings for the MbMelgan Triton inference.</p>
 
 
 | Field | Type | Label | Description |
@@ -498,7 +498,7 @@ MbMelganTriton message contains settings for the MbMelgan Triton inference.
 <a name="ondewo.t2s.Mel2Audio"></a>
 
 ### Mel2Audio
-Mel2Audio message contains settings for mel-to-audio inference.
+<p>Mel2Audio message contains settings for mel-to-audio inference.</p>
 
 
 | Field | Type | Label | Description |
@@ -516,7 +516,7 @@ Mel2Audio message contains settings for mel-to-audio inference.
 <a name="ondewo.t2s.NormalizeTextRequest"></a>
 
 ### NormalizeTextRequest
-NormalizeTextRequest message is used to request text normalization.
+<p>NormalizeTextRequest message is used to request text normalization.</p>
 
 
 | Field | Type | Label | Description |
@@ -532,7 +532,7 @@ NormalizeTextRequest message is used to request text normalization.
 <a name="ondewo.t2s.NormalizeTextResponse"></a>
 
 ### NormalizeTextResponse
-NormalizeTextResponse message is used to store the normalized text response.
+<p>NormalizeTextResponse message is used to store the normalized text response.</p>
 
 
 | Field | Type | Label | Description |
@@ -547,7 +547,7 @@ NormalizeTextResponse message is used to store the normalized text response.
 <a name="ondewo.t2s.PhonemizerId"></a>
 
 ### PhonemizerId
-PhonemizerId message represents the ID of a phonemizer.
+<p>PhonemizerId message represents the ID of a phonemizer.</p>
 
 
 | Field | Type | Label | Description |
@@ -562,7 +562,7 @@ PhonemizerId message represents the ID of a phonemizer.
 <a name="ondewo.t2s.Postprocessing"></a>
 
 ### Postprocessing
-Postprocessing message contains settings for postprocessing.
+<p>Postprocessing message contains settings for postprocessing.</p>
 
 
 | Field | Type | Label | Description |
@@ -581,7 +581,7 @@ Postprocessing message contains settings for postprocessing.
 <a name="ondewo.t2s.RequestConfig"></a>
 
 ### RequestConfig
-Represents a Configuration for the text to speech conversion.
+<p>Represents a Configuration for the text to speech conversion.</p>
 
 
 | Field | Type | Label | Description |
@@ -593,7 +593,17 @@ Represents a Configuration for the text to speech conversion.
 | pcm | [Pcm](#ondewo.t2s.Pcm) |  | Optional. Defines the pulse-code modulation of the wav file. The default value is PCM_16. |
 | audio_format | [AudioFormat](#ondewo.t2s.AudioFormat) |  | Optional. Defines the format of the desired audio. The default value is wav. |
 | use_cache | [bool](#bool) |  | Optional. Define if cache should be used or not. The default value is False. |
-| t2s_service_config | [google.protobuf.Struct](#google.protobuf.Struct) | optional | Optional. t2s_service_config provides the configuration of the service such as API key, bearer tokens, JWT, and other header information as key value pairs, e.g., <pre><code>MY_API_KEY='LKJDIFe244LKJOI'</code></pre> A. For Amazon T2S service, the following arguments should be passed: A1. aws_access_key_id (required) Access key id to access Amazon WEB Service. A2. aws_secret_access_key (required) Secret access key to access Amazon WEB Service. A3. region (required) Region name of Amazon Server. Example: t2s_config_service={'aws_access_key_id': 'YOUR_AWS_ACCESS_KEY_ID', 'aws_secret_access_key': 'YOUR_AWS_SECRET_ACCESS_KEY', 'region': 'YOUR_AMAZON_SERVER_REGION_NAME'} B. For ElevenLabs T2s service, the following arguments should be passed: B1. api_key (required) API key of ElevenLabs cloud provider to access its T2S service. Example: t2s_config_service={'api_key': 'YOUR_ELEVENLABS_API_KEY'} C. For Google cloud T2S service, the following arguments should be passed: C1. api_key (required) API key of Google cloud provider to access its T2S service. C2. api_endpoint (optional) Regional API endpoint of Google cloud T2S service. (Defaults to 'eu-texttospeech.googleapis.com') Example: t2s_config_service={'api_key': 'YOUR_GOOGLE_CLOUD_API_KEY', 'api_endpoint': 'YOUR_GOOGLE_CLOUD_API_ENDPOINT'} D. For Microsoft Azure T2s service, the following arguments should be passed: D1. subscription_key (required) Subscription key to access Microsoft Azure Service. D2. region (required) Region name of Microsoft Azure Server. Example: t2s_config_service={'subscription_key': 'YOUR_MICROSOFT_AZURE_SUBSCRIPTION_KEY', 'region': 'YOUR_MICROSOFT_AZURE_SERVER_REGION_NAME'} Note: ondewo-t2s will raise an error if you don't pass any of the required arguments above. |
+| t2s_service_config | [google.protobuf.Struct](#google.protobuf.Struct) | optional | Optional. t2s_service_config provides the configuration of the service such as API key, bearer tokens, JWT, and other header information as key value pairs, e.g., <pre><code>MY_API_KEY=&apos;LKJDIFe244LKJOI&apos;</code></pre>
+
+A. For Amazon T2S service, the following arguments should be passed: <ul> <li>A1. <code>aws_access_key_id</code> (required) Access key id to access Amazon WEB Service.</li> <li>A2. <code>aws_secret_access_key</code> (required) Secret access key to access Amazon WEB Service.</li> <li>A3. <code>region</code> (required) Region name of Amazon Server.</li> </ul> Example: <pre><code>t2s_config_service={&apos;aws_access_key_id&apos;: &apos;YOUR_AWS_ACCESS_KEY_ID&apos;, &apos;aws_secret_access_key&apos;: &apos;YOUR_AWS_SECRET_ACCESS_KEY&apos;, &apos;region&apos;: &apos;YOUR_AMAZON_SERVER_REGION_NAME&apos;}</code></pre>
+
+B. For ElevenLabs T2s service, the following arguments should be passed: <ul> <li>B1. <code>api_key</code> (required) API key of ElevenLabs cloud provider to access its T2S service.</li> </ul> Example: <pre><code>t2s_config_service={&apos;api_key&apos;: &apos;YOUR_ELEVENLABS_API_KEY&apos;}</code></pre>
+
+C. For Google cloud T2S service, the following arguments should be passed: <ul> <li>C1. <code>api_key</code> (required) API key of Google cloud provider to access its T2S service.</li> <li>C2. <code>api_endpoint</code> (optional) Regional API endpoint of Google cloud T2S service. (Defaults to &apos;eu-texttospeech.googleapis.com&apos;)</li> </ul> Example: <pre><code>t2s_config_service={&apos;api_key&apos;: &apos;YOUR_GOOGLE_CLOUD_API_KEY&apos;, &apos;api_endpoint&apos;: &apos;YOUR_GOOGLE_CLOUD_API_ENDPOINT&apos;}</code></pre>
+
+D. For Microsoft Azure T2s service, the following arguments should be passed: <ul> <li>D1. <code>subscription_key</code> (required) Subscription key to access Microsoft Azure Service.</li> <li>D2. <code>region</code> (required) Region name of Microsoft Azure Server.</li> </ul> Example: <pre><code>t2s_config_service={&apos;subscription_key&apos;: &apos;YOUR_MICROSOFT_AZURE_SUBSCRIPTION_KEY&apos;, &apos;region&apos;: &apos;YOUR_MICROSOFT_AZURE_SERVER_REGION_NAME&apos;}</code></pre>
+
+Note: ondewo-t2s will raise an error if you don&apos;t pass any of the required arguments above. |
 | t2s_cloud_provider_config | [T2sCloudProviderConfig](#ondewo.t2s.T2sCloudProviderConfig) | optional | Optional. Defines the cloud provider's specific configuration for using text to speech cloud services The default value is None. |
 | t2s_normalization | [T2SNormalization](#ondewo.t2s.T2SNormalization) |  | Optional. Define t2s_normalization config parameters for this specific request. The default values are set in the config file and the values set via RequestConfig are set just for this specific request and will not update the pipeline. |
 | word_to_phoneme_mapping | [google.protobuf.Struct](#google.protobuf.Struct) | optional | Optional. Define a dict which specifies the phonemes for a special word. |
@@ -606,7 +616,7 @@ Represents a Configuration for the text to speech conversion.
 <a name="ondewo.t2s.SingleInference"></a>
 
 ### SingleInference
-SingleInference message inference settings of text2audio models.
+<p>SingleInference message inference settings of text2audio models.</p>
 
 
 | Field | Type | Label | Description |
@@ -621,7 +631,7 @@ SingleInference message inference settings of text2audio models.
 <a name="ondewo.t2s.StreamingSynthesizeRequest"></a>
 
 ### StreamingSynthesizeRequest
-StreamingSynthesizeRequest is used to perform streaming synthesize.
+<p>StreamingSynthesizeRequest is used to perform streaming synthesize.</p>
 
 
 | Field | Type | Label | Description |
@@ -637,9 +647,9 @@ StreamingSynthesizeRequest is used to perform streaming synthesize.
 <a name="ondewo.t2s.StreamingSynthesizeResponse"></a>
 
 ### StreamingSynthesizeResponse
-Represents a Streaming Synthesize Response.
-A Streaming Synthesize Response contains the generated audio, requested text and and
-all other properties of this generated audio.
+<p>Represents a Streaming Synthesize Response.</p>
+<p>A Streaming Synthesize Response contains the generated audio, requested text and and
+all other properties of this generated audio.</p>
 
 
 | Field | Type | Label | Description |
@@ -661,37 +671,13 @@ all other properties of this generated audio.
 <a name="ondewo.t2s.SynthesizeRequest"></a>
 
 ### SynthesizeRequest
-Represents a Synthesize Request.
-A Synthesize Request contains the information need to perform a text to speech conversion.
+<p>Represents a Synthesize Request.</p>
+<p>A Synthesize Request contains the information need to perform a text to speech conversion.</p>
 
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| text | [string](#string) |  | Required. Represents the text that will be transformed to speech.
-
-<p> Synthesize text: </p>
-
-- Simple text: <pre><code>Hello, how are you?</code></pre>
-
-<p>Examples to modulate the voice based on SSML tags and Arpabet phonemes:</p>
-
-- SSML Tag Phone: <pre><code>&lt;say-as interpret-as="phone">+12354321&lt;/say-as&gt;</code></pre>
-
-- SSML Tag Email: <pre><code>&lt;say-as interpret-as="email">voices@ondewo.com&lt;/say-as&gt;</code></pre>
-
-- SSML Tag URL: <pre><code>&lt;say-as interpret-as="url">ondewo.com/en/&lt;/say-as&gt;</code></pre>
-
-- SSML Tag Spell: <pre><code>&lt;say-as interpret-as="spell">AP732&lt;/say-as&gt;</code></pre>
-
-- SSML Tag Spell With Names: <pre><code>&lt;say-as interpret-as="spell-with-names">AHO32&lt;/say-as&gt;</code></pre>
-
-- SSML Tag Callsigns Short: <pre><code>&lt;say-as interpret-as="callsign-short">AUA439&lt;/say-as&gt;</code></pre>
-
-- SSML Tag Callsigns Long: <pre><code>&lt;say-as interpret-as="callsign-long">AAL439&lt;/say-as&gt;</code></pre>
-
-- SSML Tag Break Tag: <pre><code>I am going to take a 2 seconds break <break time="2.0"/> done</code></pre>
-
-- Arpabet Phonemes: <pre><code>Hello I am {AE2 L EH0 G Z AE1 N D R AH0}</code></pre> |
+| text | [string](#string) |  | Required. Represents the text that will be transformed to speech. Synthesize text: <ul> <li>Simple text: <pre><code>Hello, how are you?</code></pre></li> </ul> Examples to modulate the voice based on SSML tags and Arpabet phonemes: <ul> <li>SSML Tag Phone: <pre><code>&lt;say-as interpret-as=&quot;phone&quot;&gt;+12354321&lt;/say-as&gt;</code></pre></li> <li>SSML Tag Email: <pre><code>&lt;say-as interpret-as=&quot;email&quot;&gt;voices@ondewo.com&lt;/say-as&gt;</code></pre></li> <li>SSML Tag URL: <pre><code>&lt;say-as interpret-as=&quot;url&quot;&gt;ondewo.com/en/&lt;/say-as&gt;</code></pre></li> <li>SSML Tag Spell: <pre><code>&lt;say-as interpret-as=&quot;spell&quot;&gt;AP732&lt;/say-as&gt;</code></pre></li> <li>SSML Tag Spell With Names: <pre><code>&lt;say-as interpret-as=&quot;spell-with-names&quot;&gt;AHO32&lt;/say-as&gt;</code></pre></li> <li>SSML Tag Callsigns Short: <pre><code>&lt;say-as interpret-as=&quot;callsign-short&quot;&gt;AUA439&lt;/say-as&gt;</code></pre></li> <li>SSML Tag Callsigns Long: <pre><code>&lt;say-as interpret-as=&quot;callsign-long&quot;&gt;AAL439&lt;/say-as&gt;</code></pre></li> <li>SSML Tag Break Tag: <pre><code>I am going to take a 2 seconds break &lt;break time=&quot;2.0&quot;/&gt; done</code></pre></li> <li>Arpabet Phonemes: <pre><code>Hello I am {AE2 L EH0 G Z AE1 N D R AH0}</code></pre></li> </ul> |
 | config | [RequestConfig](#ondewo.t2s.RequestConfig) |  | Required. Represents the specifications needed to do the text to speech transformation. |
 
 
@@ -702,8 +688,8 @@ A Synthesize Request contains the information need to perform a text to speech c
 <a name="ondewo.t2s.SynthesizeResponse"></a>
 
 ### SynthesizeResponse
-Represents a Synthesize Response.
-A Synthesize Response contains the generated audio, requested text and all other properties of this generated audio.
+<p>Represents a Synthesize Response.</p>
+<p>A Synthesize Response contains the generated audio, requested text and all other properties of this generated audio.</p>
 
 
 | Field | Type | Label | Description |
@@ -725,7 +711,7 @@ A Synthesize Response contains the generated audio, requested text and all other
 <a name="ondewo.t2s.T2SCustomLengthScales"></a>
 
 ### T2SCustomLengthScales
-T2SCustomLengthScales message contains custom length scales for text types.
+<p>T2SCustomLengthScales message contains custom length scales for text types.</p>
 
 
 | Field | Type | Label | Description |
@@ -747,7 +733,7 @@ T2SCustomLengthScales message contains custom length scales for text types.
 <a name="ondewo.t2s.T2SDescription"></a>
 
 ### T2SDescription
-T2SDescription message is used to describe the text-to-speech service.
+<p>T2SDescription message is used to describe the text-to-speech service.</p>
 
 
 | Field | Type | Label | Description |
@@ -767,7 +753,7 @@ T2SDescription message is used to describe the text-to-speech service.
 <a name="ondewo.t2s.T2SGetServiceInfoResponse"></a>
 
 ### T2SGetServiceInfoResponse
-Version information of the service
+<p>Version information of the service</p>
 
 
 | Field | Type | Label | Description |
@@ -782,7 +768,7 @@ Version information of the service
 <a name="ondewo.t2s.T2SInference"></a>
 
 ### T2SInference
-T2SInference message is used to specify the text-to-speech inference settings.
+<p>T2SInference message is used to specify the text-to-speech inference settings.</p>
 
 
 | Field | Type | Label | Description |
@@ -800,7 +786,7 @@ T2SInference message is used to specify the text-to-speech inference settings.
 <a name="ondewo.t2s.T2SNormalization"></a>
 
 ### T2SNormalization
-Represents the configuration for text-to-speech normalization.
+<p>Represents the configuration for text-to-speech normalization.</p>
 
 
 | Field | Type | Label | Description |
@@ -822,7 +808,7 @@ Represents the configuration for text-to-speech normalization.
 <a name="ondewo.t2s.T2sCloudProviderConfig"></a>
 
 ### T2sCloudProviderConfig
-Configuration for cloud provider settings for Text-to-Speech (T2S).
+<p>Configuration for cloud provider settings for Text-to-Speech (T2S).</p>
 
 
 | Field | Type | Label | Description |
@@ -839,7 +825,7 @@ Configuration for cloud provider settings for Text-to-Speech (T2S).
 <a name="ondewo.t2s.T2sCloudProviderConfigElevenLabs"></a>
 
 ### T2sCloudProviderConfigElevenLabs
-Configuration details specific to the Eleven Labs text-to-speech provider.
+<p>Configuration details specific to the Eleven Labs text-to-speech provider.</p>
 
 
 | Field | Type | Label | Description |
@@ -858,7 +844,7 @@ Configuration details specific to the Eleven Labs text-to-speech provider.
 <a name="ondewo.t2s.T2sCloudProviderConfigGoogle"></a>
 
 ### T2sCloudProviderConfigGoogle
-Configuration details specific to the Google text-to-speech provider.
+<p>Configuration details specific to the Google text-to-speech provider.</p>
 
 
 | Field | Type | Label | Description |
@@ -875,7 +861,7 @@ Configuration details specific to the Google text-to-speech provider.
 <a name="ondewo.t2s.T2sCloudProviderConfigMicrosoft"></a>
 
 ### T2sCloudProviderConfigMicrosoft
-Configuration details specific to the Microsoft text-to-speech provider.
+<p>Configuration details specific to the Microsoft text-to-speech provider.</p>
 
 
 | Field | Type | Label | Description |
@@ -890,7 +876,7 @@ Configuration details specific to the Microsoft text-to-speech provider.
 <a name="ondewo.t2s.T2sCloudServiceAmazon"></a>
 
 ### T2sCloudServiceAmazon
-T2sCloudServiceAmazon message contains settings for the Amazon Cloud service inference.
+<p>T2sCloudServiceAmazon message contains settings for the Amazon Cloud service inference.</p>
 
 
 | Field | Type | Label | Description |
@@ -906,7 +892,7 @@ T2sCloudServiceAmazon message contains settings for the Amazon Cloud service inf
 <a name="ondewo.t2s.T2sCloudServiceElevenLabs"></a>
 
 ### T2sCloudServiceElevenLabs
-T2sCloudServiceElevenLabs message contains settings for the ElevenLabs Cloud service inference.
+<p>T2sCloudServiceElevenLabs message contains settings for the ElevenLabs Cloud service inference.</p>
 
 
 | Field | Type | Label | Description |
@@ -925,7 +911,7 @@ T2sCloudServiceElevenLabs message contains settings for the ElevenLabs Cloud ser
 <a name="ondewo.t2s.T2sCloudServiceGoogle"></a>
 
 ### T2sCloudServiceGoogle
-T2sCloudServiceGoogle message contains settings for the Google Cloud service inference.
+<p>T2sCloudServiceGoogle message contains settings for the Google Cloud service inference.</p>
 
 
 | Field | Type | Label | Description |
@@ -943,7 +929,7 @@ T2sCloudServiceGoogle message contains settings for the Google Cloud service inf
 <a name="ondewo.t2s.T2sCloudServiceMicrosoft"></a>
 
 ### T2sCloudServiceMicrosoft
-T2sCloudServiceMicrosoft message contains settings for the Microsoft Cloud service inference.
+<p>T2sCloudServiceMicrosoft message contains settings for the Microsoft Cloud service inference.</p>
 
 
 | Field | Type | Label | Description |
@@ -959,8 +945,8 @@ T2sCloudServiceMicrosoft message contains settings for the Microsoft Cloud servi
 <a name="ondewo.t2s.T2sPipelineId"></a>
 
 ### T2sPipelineId
-Pipeline Id representation.
-Used in the creation, deletion and getter of pipelines.
+<p>Pipeline Id representation.</p>
+<p>Used in the creation, deletion and getter of pipelines.</p>
 
 
 | Field | Type | Label | Description |
@@ -975,7 +961,7 @@ Used in the creation, deletion and getter of pipelines.
 <a name="ondewo.t2s.Text2Audio"></a>
 
 ### Text2Audio
-Text2Audio message contains settings for text-to-audio inference.
+<p>Text2Audio message contains settings for text-to-audio inference.</p>
 
 
 | Field | Type | Label | Description |
@@ -996,7 +982,7 @@ Text2Audio message contains settings for text-to-audio inference.
 <a name="ondewo.t2s.Text2Mel"></a>
 
 ### Text2Mel
-Text2Mel message contains settings for text-to-mel inference.
+<p>Text2Mel message contains settings for text-to-mel inference.</p>
 
 
 | Field | Type | Label | Description |
@@ -1013,7 +999,7 @@ Text2Mel message contains settings for text-to-mel inference.
 <a name="ondewo.t2s.Text2SpeechConfig"></a>
 
 ### Text2SpeechConfig
-Configuration of text-to-speech models representation.
+<p>Configuration of text-to-speech models representation.</p>
 
 
 | Field | Type | Label | Description |
@@ -1033,7 +1019,7 @@ Configuration of text-to-speech models representation.
 <a name="ondewo.t2s.UpdateCustomPhonemizerRequest"></a>
 
 ### UpdateCustomPhonemizerRequest
-UpdateCustomPhonemizerRequest message represents the request for updating a custom phonemizer.
+<p>UpdateCustomPhonemizerRequest message represents the request for updating a custom phonemizer.</p>
 
 
 | Field | Type | Label | Description |
@@ -1050,7 +1036,7 @@ UpdateCustomPhonemizerRequest message represents the request for updating a cust
 <a name="ondewo.t2s.Vits"></a>
 
 ### Vits
-
+<p>Vits message contains settings for the Vits inference.</p>
 
 
 | Field | Type | Label | Description |
@@ -1071,7 +1057,7 @@ UpdateCustomPhonemizerRequest message represents the request for updating a cust
 <a name="ondewo.t2s.VitsTriton"></a>
 
 ### VitsTriton
-VitsTriton message contains settings for the Vits Triton inference.
+<p>VitsTriton message contains settings for the Vits Triton inference.</p>
 
 
 | Field | Type | Label | Description |
@@ -1094,7 +1080,7 @@ VitsTriton message contains settings for the Vits Triton inference.
 <a name="ondewo.t2s.VoiceSettings"></a>
 
 ### VoiceSettings
-VoiceSettings message contains settings for ElevenLabs inference.
+<p>VoiceSettings message contains settings for ElevenLabs inference.</p>
 
 
 | Field | Type | Label | Description |
@@ -1112,7 +1098,7 @@ VoiceSettings message contains settings for ElevenLabs inference.
 <a name="ondewo.t2s.Wiener"></a>
 
 ### Wiener
-Wiener message contains settings for Wiener postprocessing.
+<p>Wiener message contains settings for Wiener postprocessing.</p>
 
 
 | Field | Type | Label | Description |
@@ -1133,7 +1119,7 @@ Wiener message contains settings for Wiener postprocessing.
 <a name="ondewo.t2s.AudioFormat"></a>
 
 ### AudioFormat
-AudioFormat enum represents various audio file formats for storing digital audio data.
+<p>AudioFormat enum represents various audio file formats for storing digital audio data.</p>
 
 | Name | Number | Description |
 | ---- | ------ | ----------- |
@@ -1150,7 +1136,7 @@ AudioFormat enum represents various audio file formats for storing digital audio
 <a name="ondewo.t2s.Pcm"></a>
 
 ### Pcm
-Represents a pulse-code modulation technique.
+<p>Represents a pulse-code modulation technique.</p>
 
 | Name | Number | Description |
 | ---- | ------ | ----------- |
@@ -1184,62 +1170,28 @@ The update method to be used.
 <a name="ondewo.t2s.Text2Speech"></a>
 
 ### Text2Speech
-Text2Speech service provides endpoints for text-to-speech generation.
+<p>Text2Speech service provides endpoints for text-to-speech generation.</p>
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| Synthesize | [SynthesizeRequest](#ondewo.t2s.SynthesizeRequest) | [SynthesizeResponse](#ondewo.t2s.SynthesizeResponse) | Synthesize RPC
-
-Synthesizes a specific text sent in the request with the provided configuration requirements and retrieves a response that includes the synthesized text as audio and the requested configuration. |
-| BatchSynthesize | [BatchSynthesizeRequest](#ondewo.t2s.BatchSynthesizeRequest) | [BatchSynthesizeResponse](#ondewo.t2s.BatchSynthesizeResponse) | BatchSynthesize RPC
-
-Performs batch synthesis by accepting a batch of synthesis requests and returning a batch response. This can be more efficient for generating predictions on the AI model in bulk. |
-| StreamingSynthesize | [StreamingSynthesizeRequest](#ondewo.t2s.StreamingSynthesizeRequest) stream | [StreamingSynthesizeResponse](#ondewo.t2s.StreamingSynthesizeResponse) stream | Performs streaming synthesis by accepting stream of input text and returning a stream of generated audio. |
-| NormalizeText | [NormalizeTextRequest](#ondewo.t2s.NormalizeTextRequest) | [NormalizeTextResponse](#ondewo.t2s.NormalizeTextResponse) | NormalizeText RPC
-
-Normalizes a text according to the specific pipeline's normalization rules. |
-| GetT2sPipeline | [T2sPipelineId](#ondewo.t2s.T2sPipelineId) | [Text2SpeechConfig](#ondewo.t2s.Text2SpeechConfig) | GetT2sPipeline RPC
-
-Retrieves the configuration of the specified text-to-speech pipeline. |
-| CreateT2sPipeline | [Text2SpeechConfig](#ondewo.t2s.Text2SpeechConfig) | [T2sPipelineId](#ondewo.t2s.T2sPipelineId) | CreateT2sPipeline RPC
-
-Creates a new text-to-speech pipeline with the provided configuration and returns its pipeline ID. |
-| DeleteT2sPipeline | [T2sPipelineId](#ondewo.t2s.T2sPipelineId) | [.google.protobuf.Empty](#google.protobuf.Empty) | DeleteT2sPipeline RPC
-
-Deletes the specified text-to-speech pipeline. |
-| UpdateT2sPipeline | [Text2SpeechConfig](#ondewo.t2s.Text2SpeechConfig) | [.google.protobuf.Empty](#google.protobuf.Empty) | UpdateT2sPipeline RPC
-
-Updates the specified text-to-speech pipeline with the given configuration. |
-| ListT2sPipelines | [ListT2sPipelinesRequest](#ondewo.t2s.ListT2sPipelinesRequest) | [ListT2sPipelinesResponse](#ondewo.t2s.ListT2sPipelinesResponse) | ListT2sPipelines RPC
-
-Retrieves a list of text-to-speech pipelines based on specific requirements. |
-| ListT2sLanguages | [ListT2sLanguagesRequest](#ondewo.t2s.ListT2sLanguagesRequest) | [ListT2sLanguagesResponse](#ondewo.t2s.ListT2sLanguagesResponse) | ListT2sLanguages RPC
-
-Retrieves a list of languages available based on specific configuration requirements. |
-| ListT2sDomains | [ListT2sDomainsRequest](#ondewo.t2s.ListT2sDomainsRequest) | [ListT2sDomainsResponse](#ondewo.t2s.ListT2sDomainsResponse) | ListT2sDomains RPC
-
-Retrieves a list of domains available based on specific configuration requirements. |
-| ListT2sNormalizationPipelines | [ListT2sNormalizationPipelinesRequest](#ondewo.t2s.ListT2sNormalizationPipelinesRequest) | [ListT2sNormalizationPipelinesResponse](#ondewo.t2s.ListT2sNormalizationPipelinesResponse) | ListT2sNormalizationPipelines RPC
-
-Retrieves a list of normalization pipelines based on specific requirements. |
-| GetServiceInfo | [.google.protobuf.Empty](#google.protobuf.Empty) | [T2SGetServiceInfoResponse](#ondewo.t2s.T2SGetServiceInfoResponse) | GetServiceInfo RPC
-
-Retrieves the version information of the running text-to-speech server. |
-| GetCustomPhonemizer | [PhonemizerId](#ondewo.t2s.PhonemizerId) | [CustomPhonemizerProto](#ondewo.t2s.CustomPhonemizerProto) | GetCustomPhonemizer RPC
-
-Retrieves a custom phonemizer based on the provided PhonemizerId. |
-| CreateCustomPhonemizer | [CreateCustomPhonemizerRequest](#ondewo.t2s.CreateCustomPhonemizerRequest) | [PhonemizerId](#ondewo.t2s.PhonemizerId) | CreateCustomPhonemizer RPC
-
-Creates a custom phonemizer based on the provided CreateCustomPhonemizerRequest. Returns the PhonemizerId associated with the created custom phonemizer. |
-| DeleteCustomPhonemizer | [PhonemizerId](#ondewo.t2s.PhonemizerId) | [.google.protobuf.Empty](#google.protobuf.Empty) | DeleteCustomPhonemizer RPC
-
-Deletes a custom phonemizer based on the provided PhonemizerId. Returns an Empty response upon successful deletion. |
-| UpdateCustomPhonemizer | [UpdateCustomPhonemizerRequest](#ondewo.t2s.UpdateCustomPhonemizerRequest) | [CustomPhonemizerProto](#ondewo.t2s.CustomPhonemizerProto) | UpdateCustomPhonemizer RPC
-
-Updates the specified custom phonemizer with the provided configuration. |
-| ListCustomPhonemizer | [ListCustomPhonemizerRequest](#ondewo.t2s.ListCustomPhonemizerRequest) | [ListCustomPhonemizerResponse](#ondewo.t2s.ListCustomPhonemizerResponse) | ListCustomPhonemizer RPC
-
-Retrieves a list of custom phonemizers based on specific requirements. |
+| Synthesize | [SynthesizeRequest](#ondewo.t2s.SynthesizeRequest) | [SynthesizeResponse](#ondewo.t2s.SynthesizeResponse) | <p>Synthesizes a specific text sent in the request with the provided configuration requirements and retrieves a response that includes the synthesized text as audio and the requested configuration.</p> |
+| BatchSynthesize | [BatchSynthesizeRequest](#ondewo.t2s.BatchSynthesizeRequest) | [BatchSynthesizeResponse](#ondewo.t2s.BatchSynthesizeResponse) | <p>Performs batch synthesis by accepting a batch of synthesis requests and returning a batch response. This can be more efficient for generating predictions on the AI model in bulk.</p> |
+| StreamingSynthesize | [StreamingSynthesizeRequest](#ondewo.t2s.StreamingSynthesizeRequest) stream | [StreamingSynthesizeResponse](#ondewo.t2s.StreamingSynthesizeResponse) stream | <p>Performs streaming synthesis by accepting stream of input text and returning a stream of generated audio.</p> |
+| NormalizeText | [NormalizeTextRequest](#ondewo.t2s.NormalizeTextRequest) | [NormalizeTextResponse](#ondewo.t2s.NormalizeTextResponse) | <p>Normalizes a text according to the specific pipeline&apos;s normalization rules.</p> |
+| GetT2sPipeline | [T2sPipelineId](#ondewo.t2s.T2sPipelineId) | [Text2SpeechConfig](#ondewo.t2s.Text2SpeechConfig) | <p>Retrieves the configuration of the specified text-to-speech pipeline.</p> |
+| CreateT2sPipeline | [Text2SpeechConfig](#ondewo.t2s.Text2SpeechConfig) | [T2sPipelineId](#ondewo.t2s.T2sPipelineId) | <p>Creates a new text-to-speech pipeline with the provided configuration and returns its pipeline ID.</p> |
+| DeleteT2sPipeline | [T2sPipelineId](#ondewo.t2s.T2sPipelineId) | [.google.protobuf.Empty](#google.protobuf.Empty) | <p>Deletes the specified text-to-speech pipeline.</p> |
+| UpdateT2sPipeline | [Text2SpeechConfig](#ondewo.t2s.Text2SpeechConfig) | [.google.protobuf.Empty](#google.protobuf.Empty) | <p>Updates the specified text-to-speech pipeline with the given configuration.</p> |
+| ListT2sPipelines | [ListT2sPipelinesRequest](#ondewo.t2s.ListT2sPipelinesRequest) | [ListT2sPipelinesResponse](#ondewo.t2s.ListT2sPipelinesResponse) | <p>Retrieves a list of text-to-speech pipelines based on specific requirements.</p> |
+| ListT2sLanguages | [ListT2sLanguagesRequest](#ondewo.t2s.ListT2sLanguagesRequest) | [ListT2sLanguagesResponse](#ondewo.t2s.ListT2sLanguagesResponse) | <p>Retrieves a list of languages available based on specific configuration requirements.</p> |
+| ListT2sDomains | [ListT2sDomainsRequest](#ondewo.t2s.ListT2sDomainsRequest) | [ListT2sDomainsResponse](#ondewo.t2s.ListT2sDomainsResponse) | <p>Retrieves a list of domains available based on specific configuration requirements.</p> |
+| ListT2sNormalizationPipelines | [ListT2sNormalizationPipelinesRequest](#ondewo.t2s.ListT2sNormalizationPipelinesRequest) | [ListT2sNormalizationPipelinesResponse](#ondewo.t2s.ListT2sNormalizationPipelinesResponse) | <p>Retrieves a list of normalization pipelines based on specific requirements.</p> |
+| GetServiceInfo | [.google.protobuf.Empty](#google.protobuf.Empty) | [T2SGetServiceInfoResponse](#ondewo.t2s.T2SGetServiceInfoResponse) | <p>Retrieves the version information of the running text-to-speech server.</p> |
+| GetCustomPhonemizer | [PhonemizerId](#ondewo.t2s.PhonemizerId) | [CustomPhonemizerProto](#ondewo.t2s.CustomPhonemizerProto) | <p>Retrieves a custom phonemizer based on the provided PhonemizerId.</p> |
+| CreateCustomPhonemizer | [CreateCustomPhonemizerRequest](#ondewo.t2s.CreateCustomPhonemizerRequest) | [PhonemizerId](#ondewo.t2s.PhonemizerId) | <p>Creates a custom phonemizer based on the provided CreateCustomPhonemizerRequest. Returns the PhonemizerId associated with the created custom phonemizer.</p> |
+| DeleteCustomPhonemizer | [PhonemizerId](#ondewo.t2s.PhonemizerId) | [.google.protobuf.Empty](#google.protobuf.Empty) | <p>Deletes a custom phonemizer based on the provided PhonemizerId. Returns an Empty response upon successful deletion.</p> |
+| UpdateCustomPhonemizer | [UpdateCustomPhonemizerRequest](#ondewo.t2s.UpdateCustomPhonemizerRequest) | [CustomPhonemizerProto](#ondewo.t2s.CustomPhonemizerProto) | <p>Updates the specified custom phonemizer with the provided configuration.</p> |
+| ListCustomPhonemizer | [ListCustomPhonemizerRequest](#ondewo.t2s.ListCustomPhonemizerRequest) | [ListCustomPhonemizerResponse](#ondewo.t2s.ListCustomPhonemizerResponse) | <p>Retrieves a list of custom phonemizers based on specific requirements.</p> |
 
  <!-- end services -->
 

--- a/ondewo/t2s/text-to-speech.proto
+++ b/ondewo/t2s/text-to-speech.proto
@@ -18,132 +18,89 @@ package ondewo.t2s;
 import "google/protobuf/empty.proto";
 import "google/protobuf/struct.proto";
 
-// Text2Speech service provides endpoints for text-to-speech generation.
+// <p>Text2Speech service provides endpoints for text-to-speech generation.</p>
 service Text2Speech {
 
-    // Synthesize RPC
-    //
-    // Synthesizes a specific text sent in the request with the provided configuration requirements
-    // and retrieves a response that includes the synthesized text as audio and the requested configuration.
+    // <p>Synthesizes a specific text sent in the request with the provided configuration requirements
+    // and retrieves a response that includes the synthesized text as audio and the requested configuration.</p>
     rpc Synthesize(SynthesizeRequest) returns (SynthesizeResponse);
 
-    // BatchSynthesize RPC
-    //
-    // Performs batch synthesis by accepting a batch of synthesis requests and returning a batch response.
-    // This can be more efficient for generating predictions on the AI model in bulk.
+    // <p>Performs batch synthesis by accepting a batch of synthesis requests and returning a batch response.
+    // This can be more efficient for generating predictions on the AI model in bulk.</p>
     rpc BatchSynthesize(BatchSynthesizeRequest) returns (BatchSynthesizeResponse);
 
-    // Performs streaming synthesis by accepting stream of input text and returning a stream of generated audio.
+    // <p>Performs streaming synthesis by accepting stream of input text and returning a stream of generated audio.</p>
     rpc StreamingSynthesize(stream StreamingSynthesizeRequest) returns (stream StreamingSynthesizeResponse);
 
-    // NormalizeText RPC
-    //
-    // Normalizes a text according to the specific pipeline's normalization rules.
+    // <p>Normalizes a text according to the specific pipeline&apos;s normalization rules.</p>
     rpc NormalizeText(NormalizeTextRequest) returns (NormalizeTextResponse);
 
-    // GetT2sPipeline RPC
-    //
-    // Retrieves the configuration of the specified text-to-speech pipeline.
+    // <p>Retrieves the configuration of the specified text-to-speech pipeline.</p>
     rpc GetT2sPipeline(T2sPipelineId) returns (Text2SpeechConfig);
 
-    // CreateT2sPipeline RPC
-    //
-    // Creates a new text-to-speech pipeline with the provided configuration and returns its pipeline ID.
+    // <p>Creates a new text-to-speech pipeline with the provided configuration and returns its pipeline ID.</p>
     rpc CreateT2sPipeline(Text2SpeechConfig) returns (T2sPipelineId);
 
-    // DeleteT2sPipeline RPC
-    //
-    // Deletes the specified text-to-speech pipeline.
+    // <p>Deletes the specified text-to-speech pipeline.</p>
     rpc DeleteT2sPipeline(T2sPipelineId) returns (google.protobuf.Empty);
 
-    // UpdateT2sPipeline RPC
-    //
-    // Updates the specified text-to-speech pipeline with the given configuration.
+    // <p>Updates the specified text-to-speech pipeline with the given configuration.</p>
     rpc UpdateT2sPipeline(Text2SpeechConfig) returns (google.protobuf.Empty);
 
-    // ListT2sPipelines RPC
-    //
-    // Retrieves a list of text-to-speech pipelines based on specific requirements.
+    // <p>Retrieves a list of text-to-speech pipelines based on specific requirements.</p>
     rpc ListT2sPipelines(ListT2sPipelinesRequest) returns (ListT2sPipelinesResponse);
 
-    // ListT2sLanguages RPC
-    //
-    // Retrieves a list of languages available based on specific configuration requirements.
+    // <p>Retrieves a list of languages available based on specific configuration requirements.</p>
     rpc ListT2sLanguages(ListT2sLanguagesRequest) returns (ListT2sLanguagesResponse);
 
-    // ListT2sDomains RPC
-    //
-    // Retrieves a list of domains available based on specific configuration requirements.
+    // <p>Retrieves a list of domains available based on specific configuration requirements.</p>
     rpc ListT2sDomains(ListT2sDomainsRequest) returns (ListT2sDomainsResponse);
 
-    // ListT2sNormalizationPipelines RPC
-    //
-    // Retrieves a list of normalization pipelines based on specific requirements.
+    // <p>Retrieves a list of normalization pipelines based on specific requirements.</p>
     rpc ListT2sNormalizationPipelines(ListT2sNormalizationPipelinesRequest) returns (ListT2sNormalizationPipelinesResponse);
 
-    // GetServiceInfo RPC
-    //
-    // Retrieves the version information of the running text-to-speech server.
+    // <p>Retrieves the version information of the running text-to-speech server.</p>
     rpc GetServiceInfo(google.protobuf.Empty) returns (T2SGetServiceInfoResponse);
 
-    // GetCustomPhonemizer RPC
-    //
-    // Retrieves a custom phonemizer based on the provided PhonemizerId.
+    // <p>Retrieves a custom phonemizer based on the provided PhonemizerId.</p>
     rpc GetCustomPhonemizer(PhonemizerId) returns (CustomPhonemizerProto);
 
-    // CreateCustomPhonemizer RPC
-    //
-    // Creates a custom phonemizer based on the provided CreateCustomPhonemizerRequest.
-    // Returns the PhonemizerId associated with the created custom phonemizer.
+    // <p>Creates a custom phonemizer based on the provided CreateCustomPhonemizerRequest.
+    // Returns the PhonemizerId associated with the created custom phonemizer.</p>
     rpc CreateCustomPhonemizer(CreateCustomPhonemizerRequest) returns (PhonemizerId);
 
-    // DeleteCustomPhonemizer RPC
-    //
-    // Deletes a custom phonemizer based on the provided PhonemizerId.
-    // Returns an Empty response upon successful deletion.
+    // <p>Deletes a custom phonemizer based on the provided PhonemizerId.
+    // Returns an Empty response upon successful deletion.</p>
     rpc DeleteCustomPhonemizer(PhonemizerId) returns (google.protobuf.Empty);
 
-    // UpdateCustomPhonemizer RPC
-    //
-    // Updates the specified custom phonemizer with the provided configuration.
+    // <p>Updates the specified custom phonemizer with the provided configuration.</p>
     rpc UpdateCustomPhonemizer(UpdateCustomPhonemizerRequest) returns (CustomPhonemizerProto);
 
-    // ListCustomPhonemizer RPC
-    //
-    // Retrieves a list of custom phonemizers based on specific requirements.
+    // <p>Retrieves a list of custom phonemizers based on specific requirements.</p>
     rpc ListCustomPhonemizer(ListCustomPhonemizerRequest) returns (ListCustomPhonemizerResponse);
 }
 
-// Represents a Synthesize Request.
-// A Synthesize Request contains the information need to perform a text to speech conversion.
+// <p>Represents a Synthesize Request.</p>
+// <p>A Synthesize Request contains the information need to perform a text to speech conversion.</p>
 message SynthesizeRequest {
 
     // Required. Represents the text that will be transformed to speech.
-    //
-    // <p> Synthesize text: </p>
-    //
-    // - Simple text: <pre><code>Hello, how are you?</code></pre>
-    //
-    // <p>Examples to modulate the voice based on SSML tags and Arpabet phonemes:</p>
-    //
-    // - SSML Tag Phone: <pre><code>&lt;say-as interpret-as="phone">+12354321&lt;/say-as&gt;</code></pre>
-    //
-    // - SSML Tag Email: <pre><code>&lt;say-as interpret-as="email">voices@ondewo.com&lt;/say-as&gt;</code></pre>
-    //
-    // - SSML Tag URL: <pre><code>&lt;say-as interpret-as="url">ondewo.com/en/&lt;/say-as&gt;</code></pre>
-    //
-    // - SSML Tag Spell: <pre><code>&lt;say-as interpret-as="spell">AP732&lt;/say-as&gt;</code></pre>
-    //
-    // - SSML Tag Spell With Names: <pre><code>&lt;say-as interpret-as="spell-with-names">AHO32&lt;/say-as&gt;</code></pre>
-    //
-    // - SSML Tag Callsigns Short: <pre><code>&lt;say-as interpret-as="callsign-short">AUA439&lt;/say-as&gt;</code></pre>
-    //
-    // - SSML Tag Callsigns Long: <pre><code>&lt;say-as interpret-as="callsign-long">AAL439&lt;/say-as&gt;</code></pre>
-    //
-    // - SSML Tag Break Tag: <pre><code>I am going to take a 2 seconds break <break time="2.0"/> done</code></pre>
-    //
-    // - Arpabet Phonemes: <pre><code>Hello I am {AE2 L EH0 G Z AE1 N D R AH0}</code></pre>
-    //
+    // Synthesize text:
+    // <ul>
+    //   <li>Simple text: <pre><code>Hello, how are you?</code></pre></li>
+    // </ul>
+    // Examples to modulate the voice based on SSML tags and Arpabet phonemes:
+    // <ul>
+    //   <li>SSML Tag Phone: <pre><code>&lt;say-as interpret-as=&quot;phone&quot;&gt;+12354321&lt;/say-as&gt;</code></pre></li>
+    //   <li>SSML Tag Email: <pre><code>&lt;say-as interpret-as=&quot;email&quot;&gt;voices@ondewo.com&lt;/say-as&gt;</code></pre></li>
+    //   <li>SSML Tag URL: <pre><code>&lt;say-as interpret-as=&quot;url&quot;&gt;ondewo.com/en/&lt;/say-as&gt;</code></pre></li>
+    //   <li>SSML Tag Spell: <pre><code>&lt;say-as interpret-as=&quot;spell&quot;&gt;AP732&lt;/say-as&gt;</code></pre></li>
+    //   <li>SSML Tag Spell With Names: <pre><code>&lt;say-as interpret-as=&quot;spell-with-names&quot;&gt;AHO32&lt;/say-as&gt;</code></pre></li>
+    //   <li>SSML Tag Callsigns Short: <pre><code>&lt;say-as interpret-as=&quot;callsign-short&quot;&gt;AUA439&lt;/say-as&gt;</code></pre></li>
+    //   <li>SSML Tag Callsigns Long: <pre><code>&lt;say-as interpret-as=&quot;callsign-long&quot;&gt;AAL439&lt;/say-as&gt;</code></pre></li>
+    //   <li>SSML Tag Break Tag: <pre><code>I am going to take a 2 seconds break &lt;break time=&quot;2.0&quot;/&gt; done</code></pre></li>
+    //   <li>Arpabet Phonemes: <pre><code>Hello I am {AE2 L EH0 G Z AE1 N D R AH0}</code></pre></li>
+    // </ul>
     string text = 1;
 
     // Required. Represents the specifications needed to do the text to speech transformation.
@@ -151,14 +108,14 @@ message SynthesizeRequest {
 
 }
 
-// BatchSynthesizeRequest message is used to send a batch request for synthesis.
+// <p>BatchSynthesizeRequest message is used to send a batch request for synthesis.</p>
 message BatchSynthesizeRequest {
 
     // Repeated field holding individual synthesis requests that make up the batch request.
     repeated SynthesizeRequest batch_request = 1;
 }
 
-// StreamingSynthesizeRequest is used to perform streaming synthesize.
+// <p>StreamingSynthesizeRequest is used to perform streaming synthesize.</p>
 message StreamingSynthesizeRequest {
 
     // Required. Represents the text that will be transformed to speech.
@@ -170,14 +127,14 @@ message StreamingSynthesizeRequest {
 
 }
 
-// BatchSynthesizeResponse message is used to store the responses for a batch synthesis request.
+// <p>BatchSynthesizeResponse message is used to store the responses for a batch synthesis request.</p>
 message BatchSynthesizeResponse {
 
     // Repeated field holding individual synthesis responses that correspond to the input requests in the batch.
     repeated SynthesizeResponse batch_response = 1;
 }
 
-// Represents a Configuration for the text to speech conversion.
+// <p>Represents a Configuration for the text to speech conversion.</p>
 message RequestConfig {
 
     // Required. Represents the pipeline id of the model configuration that will be used.
@@ -226,31 +183,42 @@ message RequestConfig {
     reserved "normalizer";
 
     // Optional. t2s_service_config provides the configuration of the service such as API key, bearer tokens, JWT,
-    // and other header information as key value pairs, e.g., <pre><code>MY_API_KEY='LKJDIFe244LKJOI'</code></pre>
+    // and other header information as key value pairs, e.g., <pre><code>MY_API_KEY=&apos;LKJDIFe244LKJOI&apos;</code></pre>
+    //
     // A. For Amazon T2S service, the following arguments should be passed:
-    //   A1. aws_access_key_id (required) Access key id to access Amazon WEB Service.
-    //   A2. aws_secret_access_key (required) Secret access key to access Amazon WEB Service.
-    //   A3. region (required) Region name of Amazon Server.
-    //   Example:
-    //   t2s_config_service={'aws_access_key_id': 'YOUR_AWS_ACCESS_KEY_ID', 'aws_secret_access_key':
-    //  'YOUR_AWS_SECRET_ACCESS_KEY', 'region': 'YOUR_AMAZON_SERVER_REGION_NAME'}
+    // <ul>
+    //   <li>A1. <code>aws_access_key_id</code> (required) Access key id to access Amazon WEB Service.</li>
+    //   <li>A2. <code>aws_secret_access_key</code> (required) Secret access key to access Amazon WEB Service.</li>
+    //   <li>A3. <code>region</code> (required) Region name of Amazon Server.</li>
+    // </ul>
+    // Example:
+    // <pre><code>t2s_config_service={&apos;aws_access_key_id&apos;: &apos;YOUR_AWS_ACCESS_KEY_ID&apos;, &apos;aws_secret_access_key&apos;: &apos;YOUR_AWS_SECRET_ACCESS_KEY&apos;, &apos;region&apos;: &apos;YOUR_AMAZON_SERVER_REGION_NAME&apos;}</code></pre>
+    //
     // B. For ElevenLabs T2s service, the following arguments should be passed:
-    //   B1. api_key (required) API key of ElevenLabs cloud provider to access its T2S service.
-    //   Example:
-    //   t2s_config_service={'api_key': 'YOUR_ELEVENLABS_API_KEY'}
+    // <ul>
+    //   <li>B1. <code>api_key</code> (required) API key of ElevenLabs cloud provider to access its T2S service.</li>
+    // </ul>
+    // Example:
+    // <pre><code>t2s_config_service={&apos;api_key&apos;: &apos;YOUR_ELEVENLABS_API_KEY&apos;}</code></pre>
+    //
     // C. For Google cloud T2S service, the following arguments should be passed:
-    //   C1. api_key (required) API key of Google cloud provider to access its T2S service.
-    //   C2. api_endpoint (optional) Regional API endpoint of Google cloud T2S service.
-    //     (Defaults to 'eu-texttospeech.googleapis.com')
-    //   Example:
-    //   t2s_config_service={'api_key': 'YOUR_GOOGLE_CLOUD_API_KEY', 'api_endpoint': 'YOUR_GOOGLE_CLOUD_API_ENDPOINT'}
+    // <ul>
+    //   <li>C1. <code>api_key</code> (required) API key of Google cloud provider to access its T2S service.</li>
+    //   <li>C2. <code>api_endpoint</code> (optional) Regional API endpoint of Google cloud T2S service.
+    //     (Defaults to &apos;eu-texttospeech.googleapis.com&apos;)</li>
+    // </ul>
+    // Example:
+    // <pre><code>t2s_config_service={&apos;api_key&apos;: &apos;YOUR_GOOGLE_CLOUD_API_KEY&apos;, &apos;api_endpoint&apos;: &apos;YOUR_GOOGLE_CLOUD_API_ENDPOINT&apos;}</code></pre>
+    //
     // D. For Microsoft Azure T2s service, the following arguments should be passed:
-    //   D1. subscription_key (required) Subscription key to access Microsoft Azure Service.
-    //   D2. region (required) Region name of Microsoft Azure Server.
-    //   Example:
-    //   t2s_config_service={'subscription_key': 'YOUR_MICROSOFT_AZURE_SUBSCRIPTION_KEY', 'region':
-    //   'YOUR_MICROSOFT_AZURE_SERVER_REGION_NAME'}
-    // Note: ondewo-t2s will raise an error if you don't pass any of the required arguments above.
+    // <ul>
+    //   <li>D1. <code>subscription_key</code> (required) Subscription key to access Microsoft Azure Service.</li>
+    //   <li>D2. <code>region</code> (required) Region name of Microsoft Azure Server.</li>
+    // </ul>
+    // Example:
+    // <pre><code>t2s_config_service={&apos;subscription_key&apos;: &apos;YOUR_MICROSOFT_AZURE_SUBSCRIPTION_KEY&apos;, &apos;region&apos;: &apos;YOUR_MICROSOFT_AZURE_SERVER_REGION_NAME&apos;}</code></pre>
+    //
+    // Note: ondewo-t2s will raise an error if you don&apos;t pass any of the required arguments above.
     optional google.protobuf.Struct t2s_service_config = 9;
 
     // Optional. Defines the cloud provider's specific configuration for using text to speech cloud services
@@ -269,7 +237,7 @@ message RequestConfig {
 
 }
 
-// Configuration for cloud provider settings for Text-to-Speech (T2S).
+// <p>Configuration for cloud provider settings for Text-to-Speech (T2S).</p>
 message T2sCloudProviderConfig {
 
     // Configuration for Eleven Labs text-to-speech provider.
@@ -283,7 +251,7 @@ message T2sCloudProviderConfig {
 
 }
 
-// Configuration details specific to the Eleven Labs text-to-speech provider.
+// <p>Configuration details specific to the Eleven Labs text-to-speech provider.</p>
 message T2sCloudProviderConfigElevenLabs {
 
     // Stability level for inference, influencing consistency of generated speech. It is in the range [0.0, 1.0].
@@ -304,7 +272,7 @@ message T2sCloudProviderConfigElevenLabs {
 
 }
 
-// Configuration details specific to the Microsoft text-to-speech provider.
+// <p>Configuration details specific to the Microsoft text-to-speech provider.</p>
 message T2sCloudProviderConfigMicrosoft {
 
     // Determines whether to use the default speaker voice.
@@ -312,7 +280,7 @@ message T2sCloudProviderConfigMicrosoft {
 
 }
 
-// Configuration details specific to the Google text-to-speech provider.
+// <p>Configuration details specific to the Google text-to-speech provider.</p>
 message T2sCloudProviderConfigGoogle {
 
     // Speaking rate for inference, controlling the speed of generated speech. It is in the range [0.25, 4.0].
@@ -326,7 +294,7 @@ message T2sCloudProviderConfigGoogle {
 
 }
 
-// Represents a pulse-code modulation technique.
+// <p>Represents a pulse-code modulation technique.</p>
 enum Pcm {
 
     // 16-bit pulse-code modulation.
@@ -351,7 +319,7 @@ enum Pcm {
     DOUBLE = 6;
 }
 
-// AudioFormat enum represents various audio file formats for storing digital audio data.
+// <p>AudioFormat enum represents various audio file formats for storing digital audio data.</p>
 enum AudioFormat {
 
     // Waveform Audio File Format (WAV)
@@ -377,8 +345,8 @@ enum AudioFormat {
 
 }
 
-// Represents a Synthesize Response.
-// A Synthesize Response contains the generated audio, requested text and all other properties of this generated audio.
+// <p>Represents a Synthesize Response.</p>
+// <p>A Synthesize Response contains the generated audio, requested text and all other properties of this generated audio.</p>
 message SynthesizeResponse {
 
     // Required. Represents the pipeline id of the model configuration that will be used.
@@ -407,9 +375,9 @@ message SynthesizeResponse {
 
 }
 
-// Represents a Streaming Synthesize Response.
-// A Streaming Synthesize Response contains the generated audio, requested text and and
-// all other properties of this generated audio.
+// <p>Represents a Streaming Synthesize Response.</p>
+// <p>A Streaming Synthesize Response contains the generated audio, requested text and and
+// all other properties of this generated audio.</p>
 message StreamingSynthesizeResponse {
 
     // Required. Represents the pipeline id of the model configuration that will be used.
@@ -442,7 +410,7 @@ message StreamingSynthesizeResponse {
 // NORMALIZE //
 ///////////////
 
-// NormalizeTextRequest message is used to request text normalization.
+// <p>NormalizeTextRequest message is used to request text normalization.</p>
 message NormalizeTextRequest {
 
     // The ID of the text-to-speech pipeline.
@@ -453,7 +421,7 @@ message NormalizeTextRequest {
 
 }
 
-// NormalizeTextResponse message is used to store the normalized text response.
+// <p>NormalizeTextResponse message is used to store the normalized text response.</p>
 message NormalizeTextResponse {
 
     // The normalized text.
@@ -465,7 +433,7 @@ message NormalizeTextResponse {
 // GET SERVICE INFO //
 //////////////////////
 
-// Version information of the service
+// <p>Version information of the service</p>
 message T2SGetServiceInfoResponse {
 
     // version number
@@ -476,9 +444,9 @@ message T2SGetServiceInfoResponse {
 // LIST T2S PIPELINES //
 ////////////////////////
 
-// Pipeline Request representation.
-// The request message for ListT2sPipelines.
-// Filter pipelines by attributed in request.
+// <p>Pipeline Request representation.</p>
+// <p>The request message for ListT2sPipelines.</p>
+// <p>Filter pipelines by attributed in request.</p>
 message ListT2sPipelinesRequest {
 
     // Optional. Define the language/ languages.
@@ -498,8 +466,8 @@ message ListT2sPipelinesRequest {
 
 }
 
-// Pipeline Response representation.
-// The response message for ListT2sPipelines.
+// <p>Pipeline Response representation.</p>
+// <p>The response message for ListT2sPipelines.</p>
 message ListT2sPipelinesResponse {
 
     // Required. Representation of a list of pipelines configurations.
@@ -514,9 +482,9 @@ message ListT2sPipelinesResponse {
 ////////////////////////
 
 
-// Language Request representation.
-// The request message for ListT2sLanguages.
-// Filter languages of pipelines by attributed in request.
+// <p>Language Request representation.</p>
+// <p>The request message for ListT2sLanguages.</p>
+// <p>Filter languages of pipelines by attributed in request.</p>
 message ListT2sLanguagesRequest {
 
     // Optional. Define the speaker sex.
@@ -534,8 +502,8 @@ message ListT2sLanguagesRequest {
 }
 
 
-// Language Response representation.
-// The response message for ListT2sLanguages.
+// <p>Language Response representation.</p>
+// <p>The response message for ListT2sLanguages.</p>
 message ListT2sLanguagesResponse {
 
     // Required. Define the language/ languages that satisfy/ies
@@ -549,9 +517,9 @@ message ListT2sLanguagesResponse {
 //////////////////////
 
 
-// Domain Request representation.
-// The request message for ListT2sDomains.
-// Filter domains of pipelines by attributed in request.
+// <p>Domain Request representation.</p>
+// <p>The request message for ListT2sDomains.</p>
+// <p>Filter domains of pipelines by attributed in request.</p>
 message ListT2sDomainsRequest {
 
     // Optional. Define the speaker sex.
@@ -568,8 +536,8 @@ message ListT2sDomainsRequest {
 
 }
 
-// Domains Response representation.
-// The response message for ListT2sDomains.
+// <p>Domains Response representation.</p>
+// <p>The response message for ListT2sDomains.</p>
 message ListT2sDomainsResponse {
 
     // Required. Define the domain/ domains that satisfy/ies
@@ -582,8 +550,8 @@ message ListT2sDomainsResponse {
 // LIST T2S NORMALIZATION PIPELINES //
 ////////////////////////
 
-// The request message for ListT2sNormalizationPipelines.
-// Filter pipelines by attributed in request.
+// <p>The request message for ListT2sNormalizationPipelines.</p>
+// <p>Filter pipelines by attributed in request.</p>
 message ListT2sNormalizationPipelinesRequest {
 
     // Optional. Define the language.
@@ -591,8 +559,8 @@ message ListT2sNormalizationPipelinesRequest {
 
 }
 
-// Pipeline Response representation.
-// The response message for ListT2sNormalizationPipelines.
+// <p>Pipeline Response representation.</p>
+// <p>The response message for ListT2sNormalizationPipelines.</p>
 message ListT2sNormalizationPipelinesResponse {
 
     // Required. Representation of a list of normalization pipelines configurations.
@@ -607,8 +575,8 @@ message ListT2sNormalizationPipelinesResponse {
 /////////////////////////
 
 
-// Pipeline Id representation.
-// Used in the creation, deletion and getter of pipelines.
+// <p>Pipeline Id representation.</p>
+// <p>Used in the creation, deletion and getter of pipelines.</p>
 message T2sPipelineId {
 
     // Required. Defines the id of the pipeline.
@@ -620,7 +588,7 @@ message T2sPipelineId {
 // Text-to-Speech Config //
 ///////////////////////////
 
-// Configuration of text-to-speech models representation.
+// <p>Configuration of text-to-speech models representation.</p>
 message Text2SpeechConfig {
 
     // Required. Defines the id of the pipeline.
@@ -644,7 +612,7 @@ message Text2SpeechConfig {
 }
 
 
-// T2SDescription message is used to describe the text-to-speech service.
+// <p>T2SDescription message is used to describe the text-to-speech service.</p>
 message T2SDescription {
 
     // The language supported by the service.
@@ -668,7 +636,7 @@ message T2SDescription {
 
 }
 
-// T2SInference message is used to specify the text-to-speech inference settings.
+// <p>T2SInference message is used to specify the text-to-speech inference settings.</p>
 message T2SInference {
 
     // The type of inference.
@@ -684,7 +652,7 @@ message T2SInference {
     Caching caching = 4;
 }
 
-// CompositeInference message combines text-to-mel and mel-to-audio inference settings.
+// <p>CompositeInference message combines text-to-mel and mel-to-audio inference settings.</p>
 message CompositeInference {
 
     // Text-to-mel inference settings.
@@ -695,7 +663,7 @@ message CompositeInference {
 
 }
 
-// SingleInference message inference settings of text2audio models.
+// <p>SingleInference message inference settings of text2audio models.</p>
 message SingleInference {
 
     // Text-to-audio inference settings.
@@ -703,7 +671,7 @@ message SingleInference {
 
 }
 
-// Text2Mel message contains settings for text-to-mel inference.
+// <p>Text2Mel message contains settings for text-to-mel inference.</p>
 message Text2Mel {
 
     // The type of text-to-mel inference.
@@ -717,7 +685,7 @@ message Text2Mel {
 
 }
 
-// Text2Audio message contains settings for text-to-audio inference.
+// <p>Text2Audio message contains settings for text-to-audio inference.</p>
 message Text2Audio {
 
     // The type of text-to-audio inference.
@@ -743,7 +711,7 @@ message Text2Audio {
 
 }
 
-// GlowTTS message contains settings for the GlowTTS inference.
+// <p>GlowTTS message contains settings for the GlowTTS inference.</p>
 message GlowTTS {
 
     // The batch size for inference.
@@ -769,7 +737,7 @@ message GlowTTS {
 
 }
 
-// GlowTTSTriton message contains settings for the GlowTTS Triton inference.
+// <p>GlowTTSTriton message contains settings for the GlowTTS Triton inference.</p>
 message GlowTTSTriton {
 
     // The batch size for inference.
@@ -801,6 +769,7 @@ message GlowTTSTriton {
 
 }
 
+// <p>Vits message contains settings for the Vits inference.</p>
 message Vits {
 
     // The batch size for inference.
@@ -826,7 +795,7 @@ message Vits {
 
 }
 
-// VitsTriton message contains settings for the Vits Triton inference.
+// <p>VitsTriton message contains settings for the Vits Triton inference.</p>
 message VitsTriton {
 
     // The batch size for inference.
@@ -858,7 +827,7 @@ message VitsTriton {
 
 }
 
-// T2sCloudServiceElevenLabs message contains settings for the ElevenLabs Cloud service inference.
+// <p>T2sCloudServiceElevenLabs message contains settings for the ElevenLabs Cloud service inference.</p>
 message T2sCloudServiceElevenLabs {
 
     // Language of the generated audio. It should be 4-Letter language code.
@@ -878,7 +847,7 @@ message T2sCloudServiceElevenLabs {
 
 }
 
-// VoiceSettings message contains settings for ElevenLabs inference.
+// <p>VoiceSettings message contains settings for ElevenLabs inference.</p>
 message VoiceSettings{
 
     // stability value for elevenlabs inference
@@ -894,7 +863,7 @@ message VoiceSettings{
     bool use_speaker_boost = 4;
 }
 
-// T2sCloudServiceAmazon message contains settings for the Amazon Cloud service inference.
+// <p>T2sCloudServiceAmazon message contains settings for the Amazon Cloud service inference.</p>
 message T2sCloudServiceAmazon {
 
     // Voice ID indicating the speaker
@@ -905,7 +874,7 @@ message T2sCloudServiceAmazon {
 
 }
 
-// T2sCloudServiceGoogle message contains settings for the Google Cloud service inference.
+// <p>T2sCloudServiceGoogle message contains settings for the Google Cloud service inference.</p>
 message T2sCloudServiceGoogle {
 
     // Voice ID indicating the speaker
@@ -922,7 +891,7 @@ message T2sCloudServiceGoogle {
 
 }
 
-// T2sCloudServiceMicrosoft message contains settings for the Microsoft Cloud service inference.
+// <p>T2sCloudServiceMicrosoft message contains settings for the Microsoft Cloud service inference.</p>
 message T2sCloudServiceMicrosoft {
 
     // Voice ID indicating the speaker.
@@ -933,7 +902,7 @@ message T2sCloudServiceMicrosoft {
 
 }
 
-// Mel2Audio message contains settings for mel-to-audio inference.
+// <p>Mel2Audio message contains settings for mel-to-audio inference.</p>
 message Mel2Audio {
 
     // The type of mel-to-audio inference.
@@ -950,7 +919,7 @@ message Mel2Audio {
 
 }
 
-// HiFiGan message contains settings for the HiFiGan inference.
+// <p>HiFiGan message contains settings for the HiFiGan inference.</p>
 message HiFiGan {
 
     // Flag indicating whether to use GPU for inference.
@@ -967,7 +936,7 @@ message HiFiGan {
 
 }
 
-// HiFiGanTriton message contains settings for the HiFiGan Triton inference.
+// <p>HiFiGanTriton message contains settings for the HiFiGan Triton inference.</p>
 message HiFiGanTriton {
 
     // The path to the HiFiGan Triton configuration.
@@ -984,7 +953,7 @@ message HiFiGanTriton {
 
 }
 
-// MbMelganTriton message contains settings for the MbMelgan Triton inference.
+// <p>MbMelganTriton message contains settings for the MbMelgan Triton inference.</p>
 message MbMelganTriton {
 
     // The path to the MbMelgan Triton configuration.
@@ -1004,7 +973,7 @@ message MbMelganTriton {
 
 }
 
-// Caching message contains settings for caching.
+// <p>Caching message contains settings for caching.</p>
 message Caching {
 
     // Flag indicating whether caching is active.
@@ -1026,7 +995,7 @@ message Caching {
     string cache_save_dir = 6;
 
 }
-// Represents the configuration for text-to-speech normalization.
+// <p>Represents the configuration for text-to-speech normalization.</p>
 message T2SNormalization {
 
     // The language for which the normalization is applied.
@@ -1055,7 +1024,7 @@ message T2SNormalization {
 
 }
 
-// Postprocessing message contains settings for postprocessing.
+// <p>Postprocessing message contains settings for postprocessing.</p>
 message Postprocessing {
 
     // The duration of silence in seconds.
@@ -1075,7 +1044,7 @@ message Postprocessing {
 
 }
 
-// Logmnse message contains settings for Logmnse postprocessing.
+// <p>Logmnse message contains settings for Logmnse postprocessing.</p>
 message Logmnse {
 
     // The initial noise value.
@@ -1089,7 +1058,7 @@ message Logmnse {
 
 }
 
-// Wiener message contains settings for Wiener postprocessing.
+// <p>Wiener message contains settings for Wiener postprocessing.</p>
 message Wiener {
 
     // The frame length.
@@ -1109,7 +1078,7 @@ message Wiener {
 
 }
 
-// Apodization message contains settings for apodization postprocessing.
+// <p>Apodization message contains settings for apodization postprocessing.</p>
 message Apodization {
 
     // The duration of apodization in seconds.
@@ -1117,7 +1086,7 @@ message Apodization {
 
 }
 
-// T2SCustomLengthScales message contains custom length scales for text types.
+// <p>T2SCustomLengthScales message contains custom length scales for text types.</p>
 message T2SCustomLengthScales {
 
     // The custom length scale for general text.
@@ -1147,7 +1116,7 @@ message T2SCustomLengthScales {
 }
 
 
-// PhonemizerId message represents the ID of a phonemizer.
+// <p>PhonemizerId message represents the ID of a phonemizer.</p>
 message PhonemizerId {
 
     // The ID of the phonemizer.
@@ -1155,7 +1124,7 @@ message PhonemizerId {
 
 }
 
-// CustomPhonemizerProto message represents a custom phonemizer.
+// <p>CustomPhonemizerProto message represents a custom phonemizer.</p>
 message CustomPhonemizerProto {
 
     // The ID of the custom phonemizer.
@@ -1165,7 +1134,7 @@ message CustomPhonemizerProto {
     repeated Map maps = 2;
 }
 
-// Map message represents a word-to-phoneme mapping in a custom phonemizer.
+// <p>Map message represents a word-to-phoneme mapping in a custom phonemizer.</p>
 message Map {
 
     // The word to be mapped.
@@ -1176,7 +1145,7 @@ message Map {
 
 }
 
-// ListCustomPhonemizerResponse message represents the response for listing custom phonemizers.
+// <p>ListCustomPhonemizerResponse message represents the response for listing custom phonemizers.</p>
 message ListCustomPhonemizerResponse {
 
     // Repeated field of CustomPhonemizerProto messages representing the custom phonemizers.
@@ -1184,7 +1153,7 @@ message ListCustomPhonemizerResponse {
 
 }
 
-// ListCustomPhonemizerRequest message represents the request for listing custom phonemizers.
+// <p>ListCustomPhonemizerRequest message represents the request for listing custom phonemizers.</p>
 message ListCustomPhonemizerRequest {
 
     // Repeated field of pipeline IDs to filter the list of custom phonemizers.
@@ -1192,7 +1161,7 @@ message ListCustomPhonemizerRequest {
 
 }
 
-// UpdateCustomPhonemizerRequest message represents the request for updating a custom phonemizer.
+// <p>UpdateCustomPhonemizerRequest message represents the request for updating a custom phonemizer.</p>
 message UpdateCustomPhonemizerRequest {
 
     // The ID of the custom phonemizer to be updated.
@@ -1219,7 +1188,7 @@ message UpdateCustomPhonemizerRequest {
     repeated Map maps = 3;
 }
 
-// CreateCustomPhonemizerRequest message represents the request for creating a custom phonemizer.
+// <p>CreateCustomPhonemizerRequest message represents the request for creating a custom phonemizer.</p>
 message CreateCustomPhonemizerRequest {
 
     // The prefix for the custom phonemizer ID.

--- a/ondewo/t2s/text-to-speech.proto
+++ b/ondewo/t2s/text-to-speech.proto
@@ -1168,6 +1168,7 @@ message UpdateCustomPhonemizerRequest {
     string id = 1;
 
     // The update method to be used.
+    // UpdateMethod enum defines the method for updating custom phonemizers.
     enum UpdateMethod {
 
         // Add new words, replacing existing ones.


### PR DESCRIPTION
### This PR improves documentation generation and consistency across proto files by:

Adding dedicated documentation build targets to the **Makefile** to simplify and standardise the docs build process.

Updating all comments in `text-to-speech.proto` to use valid HTML formatting instead of Markdown, ensuring correct rendering in HTML-based proto documentation tools.